### PR TITLE
feat (UI): Mobile: Add padding to top of Settings page

### DIFF
--- a/src/components/organisms/ContentLayout/ContentLayout.tsx
+++ b/src/components/organisms/ContentLayout/ContentLayout.tsx
@@ -139,7 +139,7 @@ export function ContentLayout({
           )}
 
           {/* Main content area - grows to fill space, min-w-0 prevents flex overflow */}
-          <Container className={cn('w-full min-w-0 flex-1 gap-6 lg:overflow-hidden', classNameWrapperContent)}>
+          <Container className={cn('w-full min-w-0 flex-1 gap-6 pt-6 lg:overflow-hidden', classNameWrapperContent)}>
             {children}
           </Container>
 

--- a/src/components/organisms/ContentLayout/ContentLayout.tsx
+++ b/src/components/organisms/ContentLayout/ContentLayout.tsx
@@ -139,7 +139,9 @@ export function ContentLayout({
           )}
 
           {/* Main content area - grows to fill space, min-w-0 prevents flex overflow */}
-          <Container className={cn('w-full min-w-0 flex-1 gap-6 pt-6 lg:overflow-hidden', classNameWrapperContent)}>
+          <Container
+            className={cn('w-full min-w-0 flex-1 gap-6 pt-6 lg:overflow-hidden lg:pt-0', classNameWrapperContent)}
+          >
             {children}
           </Container>
 


### PR DESCRIPTION
Closes #2272 

add padding to top of the setting page for mobile U.I.

### Screenshot

<img width="469" height="681" alt="Screenshot 2026-08-13 134616" src="https://github.com/user-attachments/assets/9ec86871-ada6-4359-b1ed-9de0b5848437" />
<img width="423" height="635" alt="Screenshot 2026-08-12 134730" src="https://github.com/user-attachments/assets/243eb481-3eed-43b4-92f9-e9e2bcab9b01" />
<img width="465" height="673" alt="Screenshot 2026-08-13 134455" src="https://github.com/user-attachments/assets/3360ada0-01fb-4b1b-8dfb-b8cef3211b52" />
<img width="462" height="694" alt="Screenshot 2026-08-13 134537" src="https://github.com/user-attachments/assets/ca469474-c31f-4441-bd2f-1751e8482138" />
<img width="476" height="673" alt="Screenshot 2026-08-13 134558" src="https://github.com/user-attachments/assets/13db2dc2-d010-495e-b1f1-fc47a2604f46" />
