### PR TITLE
feat (UI): Mobile: Remove titles on Hot page

### DIFF
--- a/src/components/organisms/HotActiveUsers/HotActiveUsers.tsx
+++ b/src/components/organisms/HotActiveUsers/HotActiveUsers.tsx
@@ -74,7 +74,7 @@ export function HotActiveUsers({ limit = DEFAULT_USERS_LIMIT, className }: HotAc
 
   return (
     <Container overrideDefaults className={cn('flex w-full flex-col gap-2', className)} data-testid="hot-active-users">
-      <Heading level={5} size="lg" className="font-light text-muted-foreground">
+      <Heading level={5} size="lg" className="hidden font-light text-muted-foreground lg:block">
         {'Active users'}
       </Heading>
       {error ? (

--- a/src/components/organisms/HotTagsCardsSection/HotTagsCardsSection.tsx
+++ b/src/components/organisms/HotTagsCardsSection/HotTagsCardsSection.tsx
@@ -82,7 +82,7 @@ export function HotTagsCardsSection({ className }: HotTagsCardsSectionProps) {
   if (error) {
     return (
       <Container overrideDefaults className={cn('flex w-full flex-col gap-2', className)}>
-        <Heading level={5} size="lg" className="font-light text-muted-foreground">
+        <Heading level={5} size="lg" className="hidden font-light text-muted-foreground lg:block">
           {'Hot tags'}
         </Heading>
         <Typography className="text-destructive">{'Failed to load tags'}</Typography>
@@ -93,7 +93,7 @@ export function HotTagsCardsSection({ className }: HotTagsCardsSectionProps) {
   if (isEffectivelyLoading) {
     return (
       <Container overrideDefaults className={cn('flex w-full flex-col gap-2', className)}>
-        <Heading level={5} size="lg" className="font-light text-muted-foreground">
+        <Heading level={5} size="lg" className="hidden font-light text-muted-foreground lg:block">
           {'Hot tags'}
         </Heading>
         <HotTagsCardsSectionSkeleton maxAvatars={maxAvatars} />
@@ -107,7 +107,7 @@ export function HotTagsCardsSection({ className }: HotTagsCardsSectionProps) {
       className={cn('flex w-full flex-col gap-2', className)}
       data-testid="hot-tags-cards-section"
     >
-      <Heading level={5} size="lg" className="font-light text-muted-foreground">
+      <Heading level={5} size="lg" className="hidden font-light text-muted-foreground lg:block">
         {'Hot tags'}
       </Heading>
       {featuredTags.length === 0 ? (

--- a/src/components/templates/Feed/Hot/Hot.tsx
+++ b/src/components/templates/Feed/Hot/Hot.tsx
@@ -55,7 +55,7 @@ export function Hot() {
 
       {/* Trending Posts - hidden via CSS when another tab is active on mobile */}
       <Container overrideDefaults className={cn('flex flex-col gap-2', hidePosts && 'hidden')}>
-        <Heading level={5} size="lg" className="font-light text-muted-foreground">
+        <Heading level={5} size="lg" className="hidden font-light text-muted-foreground lg:block">
           {'Trending posts'}
         </Heading>
         <TimelineFeed variant={TIMELINE_FEED_VARIANT.HOT} />


### PR DESCRIPTION
Closes #2271 

Removed titles on Hot page for mobile and smaller screens.

### Screenrecording

https://github.com/user-attachments/assets/29b1c2cc-264a-4172-a2d3-8b74410bd95a

