### PR TITLE
feat(ui): show status emojis next to user names

### DIFF
--- a/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.test.tsx
+++ b/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TooltipProvider } from '@/atoms/Tooltip/Tooltip';
 import { formatPublicKey } from '@/libs/utils/utils';
 import { PostHeaderUserInfo } from './PostHeaderUserInfo';
 
@@ -272,6 +274,67 @@ describe('PostHeaderUserInfo', () => {
     expect(avatars.length).toBeGreaterThan(0);
     expect(screen.getAllByText('Test User').length).toBeGreaterThan(0);
     expect(screen.getAllByText(`@${formattedPublicKey}`).length).toBeGreaterThan(0);
+  });
+
+  it('renders a status emoji immediately after the user name', () => {
+    render(
+      <TooltipProvider delayDuration={0}>
+        <PostHeaderUserInfo userId="userpubkykey" userName="Test User" status="vacationing" />
+      </TooltipProvider>,
+    );
+
+    const userName = screen.getAllByText('Test User')[0];
+    const statusEmoji = screen.getByRole('button', { name: 'Vacationing status' });
+
+    expect(userName.parentElement?.nextElementSibling).toBe(statusEmoji);
+    expect(statusEmoji).toHaveTextContent('🌴');
+  });
+
+  it('shows the status label in a tooltip when the emoji is hovered', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipProvider delayDuration={0}>
+        <PostHeaderUserInfo userId="userpubkykey" userName="Test User" status="vacationing" />
+      </TooltipProvider>,
+    );
+
+    await user.hover(screen.getByRole('button', { name: 'Vacationing status' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Vacationing');
+      expect(document.querySelector('[data-slot="tooltip-content"]')).toHaveClass(
+        'bg-accent',
+        'font-medium',
+        'text-foreground',
+        '[&_svg]:fill-accent',
+      );
+    });
+  });
+
+  it('shows the status label when the emoji is tapped without bubbling to the post', async () => {
+    const onPostClick = vi.fn();
+
+    render(
+      <TooltipProvider delayDuration={0}>
+        <div onClick={onPostClick}>
+          <PostHeaderUserInfo userId="userpubkykey" userName="Test User" status="vacationing" />
+        </div>
+      </TooltipProvider>,
+    );
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Vacationing status' }), { pointerType: 'touch' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Vacationing');
+    });
+    expect(onPostClick).not.toHaveBeenCalled();
+  });
+
+  it('does not render a status emoji for no status', () => {
+    render(<PostHeaderUserInfo userId="userpubkykey" userName="Test User" status="noStatus" />);
+
+    expect(screen.queryByRole('button', { name: /status/i })).not.toBeInTheDocument();
   });
 
   it('renders avatar with image when avatarUrl is provided', () => {

--- a/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.tsx
+++ b/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import { useState } from 'react';
 import { getUserProfileUrl } from '@/app/routes';
 import { Container } from '@/atoms/Container/Container';
 import { Link } from '@/atoms/Link/Link';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/atoms/Tooltip/Tooltip';
 import { Typography } from '@/atoms/Typography/Typography';
+import { parseStatus } from '@/libs/status/status';
 import { cn, formatPublicKey } from '@/libs/utils/utils';
 import { AvatarWithFallback } from '@/organisms/AvatarWithFallback/AvatarWithFallback';
 import { useAuthStore } from '@/stores/auth/auth.store';
@@ -20,6 +23,7 @@ import {
 interface PostHeaderUserInfoProps {
   userId: string;
   userName: string;
+  status?: string | null;
   avatarUrl?: string;
   showPopover?: boolean;
   showUserInfo?: boolean;
@@ -37,6 +41,7 @@ interface PostHeaderUserInfoProps {
 export function PostHeaderUserInfo({
   userId,
   userName,
+  status,
   avatarUrl,
   showPopover = true,
   showUserInfo = true,
@@ -47,7 +52,9 @@ export function PostHeaderUserInfo({
   characterLimit,
   characterLimitPlacement = 'metadata',
 }: PostHeaderUserInfoProps) {
+  const [isStatusTooltipOpen, setIsStatusTooltipOpen] = useState(false);
   const formattedPublicKey = formatPublicKey({ key: userId });
+  const parsedStatus = parseStatus(status || '');
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   const profileUrl = getUserProfileUrl(userId, currentUserPubky);
 
@@ -87,7 +94,7 @@ export function PostHeaderUserInfo({
     </Typography>
   );
 
-  const userNameContent = (
+  const userNameLink = (
     <Link href={profileUrl} onClick={handleLinkClick} className="block w-fit max-w-full min-w-0 overflow-hidden">
       <Typography
         className={cn(
@@ -99,6 +106,45 @@ export function PostHeaderUserInfo({
         {userName}
       </Typography>
     </Link>
+  );
+
+  const userNameContent = parsedStatus.emoji ? (
+    <Container overrideDefaults className="flex max-w-full min-w-0 items-center gap-1.5">
+      {userNameLink}
+      <Tooltip open={isStatusTooltipOpen} onOpenChange={setIsStatusTooltipOpen}>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={`${parsedStatus.text} status`}
+            className={cn(
+              'shrink-0 rounded-sm border-0 bg-transparent p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
+              USERNAME_CLASS_BY_HEADER_SIZE[size],
+            )}
+            onPointerDown={(event) => {
+              event.stopPropagation();
+
+              if (event.pointerType !== 'touch') return;
+
+              event.preventDefault();
+              setIsStatusTooltipOpen((open) => !open);
+            }}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+          >
+            {parsedStatus.emoji}
+          </button>
+        </TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent className="bg-accent font-medium text-foreground [&_svg]:fill-accent">
+            {parsedStatus.text}
+          </TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </Container>
+  ) : (
+    userNameLink
   );
 
   // This container is also the UserInfoPopover hover target when showPopover is true, so it

--- a/src/components/molecules/StatusPicker/StatusPickerContent/StatusPickerContent.test.tsx
+++ b/src/components/molecules/StatusPicker/StatusPickerContent/StatusPickerContent.test.tsx
@@ -57,6 +57,16 @@ describe('StatusPickerContent', () => {
       expect(screen.getByText(STATUS_EMOJIS.available)).toBeInTheDocument();
       expect(screen.getByText(STATUS_EMOJIS.away)).toBeInTheDocument();
       expect(screen.getByText(STATUS_EMOJIS.vacationing)).toBeInTheDocument();
+      expect(screen.queryByText('💭')).not.toBeInTheDocument();
+    });
+
+    it('renders an empty bordered circle for no status', () => {
+      render(<StatusPickerContent onStatusSelect={mockOnStatusSelect} />);
+
+      const noStatusButton = screen.getByText(STATUS_LABELS.noStatus).closest('button');
+      const noStatusIcon = noStatusButton?.querySelector('[aria-hidden="true"]');
+
+      expect(noStatusIcon).toHaveClass('size-4', 'rounded-full', 'border', 'border-border');
     });
 
     it('renders custom status section', () => {

--- a/src/components/molecules/StatusPicker/StatusPickerContent/StatusPickerContent.test.tsx.snap
+++ b/src/components/molecules/StatusPicker/StatusPickerContent/StatusPickerContent.test.tsx.snap
@@ -146,9 +146,10 @@ exports[`StatusPickerContent > Snapshots > matches snapshot with custom status 1
       class="flex items-center gap-2"
       data-testid="container"
     >
-      <span>
-        💭
-      </span>
+      <span
+        aria-hidden="true"
+        class="size-4 shrink-0 rounded-full border border-border"
+      />
       <span
         class="text-base leading-6 font-medium transition-colors text-muted-foreground group-hover:text-popover-foreground"
         data-testid="typography"
@@ -346,9 +347,10 @@ exports[`StatusPickerContent > Snapshots > matches snapshot with no current stat
       class="flex items-center gap-2"
       data-testid="container"
     >
-      <span>
-        💭
-      </span>
+      <span
+        aria-hidden="true"
+        class="size-4 shrink-0 rounded-full border border-border"
+      />
       <span
         class="text-base leading-6 font-medium transition-colors text-muted-foreground group-hover:text-popover-foreground"
         data-testid="typography"
@@ -592,9 +594,10 @@ exports[`StatusPickerContent > Snapshots > matches snapshot with predefined stat
       class="flex items-center gap-2"
       data-testid="container"
     >
-      <span>
-        💭
-      </span>
+      <span
+        aria-hidden="true"
+        class="size-4 shrink-0 rounded-full border border-border"
+      />
       <span
         class="text-base leading-6 font-medium transition-colors text-muted-foreground group-hover:text-popover-foreground"
         data-testid="typography"

--- a/src/components/molecules/StatusPicker/StatusPickerContent/StatusPickerContent.tsx
+++ b/src/components/molecules/StatusPicker/StatusPickerContent/StatusPickerContent.tsx
@@ -74,7 +74,11 @@ export function StatusPickerContent({ onStatusSelect, currentStatus }: StatusPic
             className={cn('w-full justify-between gap-2 p-0', 'inline-flex cursor-pointer items-center', 'group')}
           >
             <Container overrideDefaults className="flex items-center gap-2">
-              <span>{option.emoji}</span>
+              {option.emoji ? (
+                <span>{option.emoji}</span>
+              ) : (
+                <span aria-hidden="true" className="size-4 shrink-0 rounded-full border border-border" />
+              )}
               <Typography
                 as="span"
                 className={cn(

--- a/src/components/organisms/PostHeader/PostHeader.test.tsx
+++ b/src/components/organisms/PostHeader/PostHeader.test.tsx
@@ -87,6 +87,7 @@ vi.mock('@/molecules/PostHeaderUserInfo/PostHeaderUserInfo', () => {
       ({
         userId,
         userName,
+        status,
         size,
         timeAgo,
         showUserInfo = true,
@@ -96,6 +97,7 @@ vi.mock('@/molecules/PostHeaderUserInfo/PostHeaderUserInfo', () => {
       }: {
         userId: string;
         userName: string;
+        status?: string | null;
         size?: 'normal' | 'large' | 'extraLarge';
         timeAgo?: string | null;
         showUserInfo?: boolean;
@@ -105,6 +107,7 @@ vi.mock('@/molecules/PostHeaderUserInfo/PostHeaderUserInfo', () => {
       }) => (
         <div
           data-testid="post-header-user-info"
+          data-status={status || undefined}
           data-size={size}
           data-show-user-info={showUserInfo}
           data-visually-hide-avatar={visuallyHideAvatar || undefined}
@@ -197,7 +200,12 @@ describe('PostHeader', () => {
       isLoading: false,
     });
     mockUseUserDetails.mockReturnValue({
-      userDetails: { id: 'userpubkykey', name: 'Test User', image: 'test-image-id' } as NexusUserDetails,
+      userDetails: {
+        id: 'userpubkykey',
+        name: 'Test User',
+        image: 'test-image-id',
+        status: 'vacationing',
+      } as NexusUserDetails,
       isLoading: false,
     });
     mockUseAvatarUrl.mockReturnValue('https://example.com/avatar/userpubkykey.png');
@@ -206,6 +214,7 @@ describe('PostHeader', () => {
 
     expect(screen.getByTestId('avatar')).toBeInTheDocument();
     expect(screen.getByText('Test User')).toBeInTheDocument();
+    expect(screen.getByTestId('post-header-user-info')).toHaveAttribute('data-status', 'vacationing');
     expect(screen.getByText('2h')).toBeInTheDocument();
   });
 

--- a/src/components/organisms/PostHeader/PostHeader.tsx
+++ b/src/components/organisms/PostHeader/PostHeader.tsx
@@ -66,6 +66,7 @@ export function PostHeader({
     <PostHeaderUserInfo
       userId={userId}
       userName={userDetails?.name || ''}
+      status={userDetails?.status}
       avatarUrl={avatarUrl}
       showPopover={showPopover}
       showUserInfo={showUserInfo}

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
@@ -1,9 +1,14 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TooltipProvider } from '@/atoms/Tooltip/Tooltip';
 import { FOLLOW_ACTIONS } from '@/hooks/useFollowUser/useFollowUser.types';
 import { resetViewport, setMobileViewport } from '@/test-utils/viewport';
 import { ProfilePageHeader } from './ProfilePageHeader';
 import { ProfilePageHeaderProps } from './ProfilePageHeader.types';
+
+const render = (ui: ReactElement) => rtlRender(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
 
 // Mock Molecules components
 vi.mock('@/molecules/PostText/PostText', () => {
@@ -146,6 +151,19 @@ describe('ProfilePageHeader', () => {
     ).toBeInTheDocument();
   });
 
+  it('places spacing before the actions instead of between the name and bio', () => {
+    render(<ProfilePageHeader {...mockProps} />);
+
+    const header = screen.getByTestId('profile-page-header');
+    const bio = document.querySelector('[data-cy="profile-bio-header"]');
+    const actions = screen.getByText('Edit profile').closest('button')?.parentElement;
+
+    expect(header).toHaveClass('gap-y-3');
+    expect(bio?.parentElement).toHaveClass('lg:gap-0');
+    expect(bio?.nextElementSibling).toBe(actions);
+    expect(actions).toHaveClass('lg:mt-3');
+  });
+
   it('renders formatted public key', () => {
     render(<ProfilePageHeader {...mockProps} />);
 
@@ -164,12 +182,21 @@ describe('ProfilePageHeader', () => {
     expect(screen.getByText('83 FOLLOWERS')).toBeInTheDocument();
   });
 
-  it('renders the status picker when own profile has no status', () => {
-    const props = { ...mockProps, profile: { ...mockProps.profile, status: '' } };
+  it('places the status picker below the action buttons on mobile', () => {
+    render(<ProfilePageHeader {...mockProps} />);
+
+    const statusPicker = screen.getByText('Vacationing').closest('button')?.parentElement;
+
+    expect(statusPicker).toHaveClass('order-last', 'col-span-2', 'lg:order-0', 'lg:col-auto');
+  });
+
+  it('renders the status picker without an emoji when own profile chooses no status', () => {
+    const props = { ...mockProps, profile: { ...mockProps.profile, status: 'noStatus' } };
 
     render(<ProfilePageHeader {...props} />);
 
     expect(screen.getByText('No Status')).toBeInTheDocument();
+    expect(screen.queryByText('💭')).not.toBeInTheDocument();
   });
 
   it('calls onEdit when Edit button is clicked', () => {
@@ -223,12 +250,42 @@ describe('ProfilePageHeader', () => {
     expect(screen.getByText('SN')).toBeInTheDocument();
   });
 
-  it('renders emoji badge', () => {
+  it('renders the status emoji after the name instead of on the avatar', () => {
     render(<ProfilePageHeader {...mockProps} />);
 
-    // Emoji appears in both badge and status picker, so check for multiple instances
-    const emojis = screen.getAllByText('🌴');
-    expect(emojis.length).toBeGreaterThan(0);
+    const name = screen.getByText('Satoshi Nakamoto');
+    const statusEmoji = screen.getByRole('button', { name: 'Vacationing status' });
+
+    expect(name.nextElementSibling).toBe(statusEmoji);
+    expect(screen.getByTestId('avatar').parentElement).not.toHaveTextContent('🌴');
+  });
+
+  it('shows the status label in a tooltip when the profile emoji is hovered', async () => {
+    const user = userEvent.setup();
+
+    render(<ProfilePageHeader {...mockProps} />);
+
+    await user.hover(screen.getByRole('button', { name: 'Vacationing status' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Vacationing');
+      expect(document.querySelector('[data-slot="tooltip-content"]')).toHaveClass(
+        'bg-accent',
+        'font-medium',
+        'text-foreground',
+        '[&_svg]:fill-accent',
+      );
+    });
+  });
+
+  it('shows the status label when the profile emoji is tapped', async () => {
+    render(<ProfilePageHeader {...mockProps} />);
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Vacationing status' }), { pointerType: 'touch' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Vacationing');
+    });
   });
 
   it('renders without bio', () => {
@@ -380,14 +437,15 @@ describe('ProfilePageHeader - Other User Profile', () => {
     expect(onFollowToggle).toHaveBeenCalledTimes(1);
   });
 
-  it('shows status inline with buttons when viewing other user', () => {
+  it('shows another user status only beside their name', () => {
     render(<ProfilePageHeader {...mockOtherUserProps} />);
 
-    // The status should be shown inline with buttons (emoji and text in separate elements)
-    // Emoji appears both in avatar badge and status display
-    const emojis = screen.getAllByText('🎉');
-    expect(emojis.length).toBeGreaterThanOrEqual(2); // Badge + status
-    expect(screen.getByText('Active')).toBeInTheDocument();
+    const name = screen.getByText('Other User');
+    const statusEmoji = screen.getByRole('button', { name: 'Active status' });
+
+    expect(name.nextElementSibling).toBe(statusEmoji);
+    expect(screen.getAllByText('🎉')).toHaveLength(1);
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
   });
 
   it('always shows Follow button when onFollowToggle is provided (auth handled by parent)', () => {

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
@@ -91,7 +91,7 @@ const mockProps: ProfilePageHeaderProps = {
     name: 'Satoshi Nakamoto',
     bio: 'Authored the Bitcoin white paper, developed Bitcoin, mined first block, disappeared.',
     publicKey: '1QX7GKW3abcdef1234567890',
-    status: 'Vacationing',
+    status: 'vacationing',
     emoji: '🌴',
     link: 'https://example.com',
   },
@@ -124,7 +124,7 @@ const mockOtherUserProps: ProfilePageHeaderProps = {
     name: 'Other User',
     bio: 'Some bio',
     publicKey: 'other123456789012345',
-    status: 'Active',
+    status: '🎉 Active',
     emoji: '🎉',
     link: 'https://example.com/other',
   },
@@ -258,6 +258,16 @@ describe('ProfilePageHeader', () => {
 
     expect(name.nextElementSibling).toBe(statusEmoji);
     expect(screen.getByTestId('avatar').parentElement).not.toHaveTextContent('🌴');
+  });
+
+  it('does not add a fallback emoji to a text-only custom status', () => {
+    const props = { ...mockProps, profile: { ...mockProps.profile, status: 'Focused' } };
+
+    render(<ProfilePageHeader {...props} />);
+
+    expect(screen.getByText('Satoshi Nakamoto').nextElementSibling).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Focused status' })).not.toBeInTheDocument();
+    expect(screen.queryByText('🌴')).not.toBeInTheDocument();
   });
 
   it('shows the status label in a tooltip when the profile emoji is hovered', async () => {

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
@@ -145,13 +145,13 @@ describe('ProfilePageHeader', () => {
   it('renders name and bio correctly', () => {
     render(<ProfilePageHeader {...mockProps} />);
 
-    expect(screen.getByText('Satoshi Nakamoto')).toBeInTheDocument();
+    expect(screen.getByText('Satoshi Nakamoto')).toHaveClass('leading-8', 'lg:leading-none');
     expect(
       screen.getByText('Authored the Bitcoin white paper, developed Bitcoin, mined first block, disappeared.'),
     ).toBeInTheDocument();
   });
 
-  it('places spacing before the actions instead of between the name and bio', () => {
+  it('uses the original responsive spacing between profile sections', () => {
     render(<ProfilePageHeader {...mockProps} />);
 
     const header = screen.getByTestId('profile-page-header');
@@ -159,9 +159,9 @@ describe('ProfilePageHeader', () => {
     const actions = screen.getByText('Edit profile').closest('button')?.parentElement;
 
     expect(header).toHaveClass('gap-y-3');
-    expect(bio?.parentElement).toHaveClass('lg:gap-0');
+    expect(bio?.parentElement).toHaveClass('lg:gap-3');
     expect(bio?.nextElementSibling).toBe(actions);
-    expect(actions).toHaveClass('lg:mt-3');
+    expect(actions).not.toHaveClass('lg:mt-3');
   });
 
   it('renders formatted public key', () => {

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
@@ -20,28 +20,35 @@ exports[`ProfilePageHeader - Mobile Snapshots > matches snapshot on mobile viewp
         SN
       </div>
     </div>
-    <div
-      class="absolute -right-1 -bottom-1 flex size-10 items-center justify-center text-3xl leading-none lg:size-16 lg:text-5xl"
-      data-testid="container"
-    >
-      🌴
-    </div>
   </div>
   <div
-    class="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-3"
+    class="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-0"
     data-testid="container"
   >
     <div
       class="col-start-2 row-start-1 flex min-w-0 flex-col items-start gap-1 self-center lg:col-auto lg:row-auto lg:self-auto lg:text-left"
       data-testid="container"
     >
-      <h1
-        class="font-bold max-width-profile-page-header w-full truncate text-2xl leading-normal text-white sm:max-w-xl lg:max-w-full lg:text-6xl"
-        data-cy="profile-username-header"
-        data-testid="typography"
+      <div
+        class="max-width-profile-page-header flex w-fit min-w-0 items-center gap-2 sm:max-w-xl lg:max-w-full lg:gap-3"
+        data-testid="container"
       >
-        Satoshi Nakamoto
-      </h1>
+        <h1
+          class="font-bold min-w-0 truncate text-2xl leading-normal text-white lg:text-6xl"
+          data-cy="profile-username-header"
+          data-testid="typography"
+        >
+          Satoshi Nakamoto
+        </h1>
+        <button
+          aria-label="Vacationing status"
+          class="shrink-0 rounded-sm border-0 bg-transparent p-0 text-2xl leading-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none lg:text-5xl"
+          data-state="closed"
+          type="button"
+        >
+          🌴
+        </button>
+      </div>
       <div
         class="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 lg:hidden"
         data-testid="container"
@@ -130,7 +137,7 @@ exports[`ProfilePageHeader - Mobile Snapshots > matches snapshot on mobile viewp
       </div>
     </div>
     <div
-      class="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:flex lg:flex-wrap lg:gap-3"
+      class="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:mt-3 lg:flex lg:flex-wrap lg:gap-3"
       data-testid="container"
     >
       <button
@@ -255,7 +262,7 @@ exports[`ProfilePageHeader - Mobile Snapshots > matches snapshot on mobile viewp
         Sign out
       </button>
       <div
-        class="order-first col-span-2 flex h-8 items-center lg:order-0 lg:col-auto"
+        class="order-last col-span-2 flex h-8 items-center lg:order-0 lg:col-auto"
         data-testid="container"
       >
         <button
@@ -317,28 +324,35 @@ exports[`ProfilePageHeader - Snapshots > matches snapshot 1`] = `
         SN
       </div>
     </div>
-    <div
-      class="absolute -right-1 -bottom-1 flex size-10 items-center justify-center text-3xl leading-none lg:size-16 lg:text-5xl"
-      data-testid="container"
-    >
-      🌴
-    </div>
   </div>
   <div
-    class="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-3"
+    class="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-0"
     data-testid="container"
   >
     <div
       class="col-start-2 row-start-1 flex min-w-0 flex-col items-start gap-1 self-center lg:col-auto lg:row-auto lg:self-auto lg:text-left"
       data-testid="container"
     >
-      <h1
-        class="font-bold max-width-profile-page-header w-full truncate text-2xl leading-normal text-white sm:max-w-xl lg:max-w-full lg:text-6xl"
-        data-cy="profile-username-header"
-        data-testid="typography"
+      <div
+        class="max-width-profile-page-header flex w-fit min-w-0 items-center gap-2 sm:max-w-xl lg:max-w-full lg:gap-3"
+        data-testid="container"
       >
-        Satoshi Nakamoto
-      </h1>
+        <h1
+          class="font-bold min-w-0 truncate text-2xl leading-normal text-white lg:text-6xl"
+          data-cy="profile-username-header"
+          data-testid="typography"
+        >
+          Satoshi Nakamoto
+        </h1>
+        <button
+          aria-label="Vacationing status"
+          class="shrink-0 rounded-sm border-0 bg-transparent p-0 text-2xl leading-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none lg:text-5xl"
+          data-state="closed"
+          type="button"
+        >
+          🌴
+        </button>
+      </div>
       <div
         class="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 lg:hidden"
         data-testid="container"
@@ -427,7 +441,7 @@ exports[`ProfilePageHeader - Snapshots > matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:flex lg:flex-wrap lg:gap-3"
+      class="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:mt-3 lg:flex lg:flex-wrap lg:gap-3"
       data-testid="container"
     >
       <button
@@ -552,7 +566,7 @@ exports[`ProfilePageHeader - Snapshots > matches snapshot 1`] = `
         Sign out
       </button>
       <div
-        class="order-first col-span-2 flex h-8 items-center lg:order-0 lg:col-auto"
+        class="order-last col-span-2 flex h-8 items-center lg:order-0 lg:col-auto"
         data-testid="container"
       >
         <button

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
@@ -276,6 +276,11 @@ exports[`ProfilePageHeader - Mobile Snapshots > matches snapshot on mobile viewp
           type="button"
         >
           <span
+            class="text-base leading-6"
+          >
+            🌴
+          </span>
+          <span
             class="text-base leading-6 font-bold text-white"
           >
             Vacationing
@@ -581,6 +586,11 @@ exports[`ProfilePageHeader - Snapshots > matches snapshot 1`] = `
           data-variant="ghost"
           type="button"
         >
+          <span
+            class="text-base leading-6"
+          >
+            🌴
+          </span>
           <span
             class="text-base leading-6 font-bold text-white"
           >

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`ProfilePageHeader - Mobile Snapshots > matches snapshot on mobile viewp
     </div>
   </div>
   <div
-    class="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-0"
+    class="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-3"
     data-testid="container"
   >
     <div
@@ -34,7 +34,7 @@ exports[`ProfilePageHeader - Mobile Snapshots > matches snapshot on mobile viewp
         data-testid="container"
       >
         <h1
-          class="font-bold min-w-0 truncate text-2xl leading-normal text-white lg:text-6xl"
+          class="font-bold min-w-0 truncate text-2xl leading-8 text-white lg:text-6xl lg:leading-none"
           data-cy="profile-username-header"
           data-testid="typography"
         >
@@ -137,7 +137,7 @@ exports[`ProfilePageHeader - Mobile Snapshots > matches snapshot on mobile viewp
       </div>
     </div>
     <div
-      class="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:mt-3 lg:flex lg:flex-wrap lg:gap-3"
+      class="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:flex lg:flex-wrap lg:gap-3"
       data-testid="container"
     >
       <button
@@ -331,7 +331,7 @@ exports[`ProfilePageHeader - Snapshots > matches snapshot 1`] = `
     </div>
   </div>
   <div
-    class="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-0"
+    class="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-3"
     data-testid="container"
   >
     <div
@@ -343,7 +343,7 @@ exports[`ProfilePageHeader - Snapshots > matches snapshot 1`] = `
         data-testid="container"
       >
         <h1
-          class="font-bold min-w-0 truncate text-2xl leading-normal text-white lg:text-6xl"
+          class="font-bold min-w-0 truncate text-2xl leading-8 text-white lg:text-6xl lg:leading-none"
           data-cy="profile-username-header"
           data-testid="typography"
         >
@@ -446,7 +446,7 @@ exports[`ProfilePageHeader - Snapshots > matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:mt-3 lg:flex lg:flex-wrap lg:gap-3"
+      class="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:flex lg:flex-wrap lg:gap-3"
       data-testid="container"
     >
       <button

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import {
   Check,
   Ellipsis,
@@ -12,9 +13,9 @@ import {
   UserRoundPlus,
   UsersRound,
 } from 'lucide-react';
-import { AvatarEmojiBadge } from '@/atoms/AvatarEmojiBadge/AvatarEmojiBadge';
 import { Button } from '@/atoms/Button/Button';
 import { Container } from '@/atoms/Container/Container';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/atoms/Tooltip/Tooltip';
 import { Typography } from '@/atoms/Typography/Typography';
 import { FOLLOW_ACTIONS } from '@/hooks/useFollowUser/useFollowUser.types';
 import { useTtlSubscription } from '@/hooks/useTtlSubscription/useTtlSubscription';
@@ -69,7 +70,9 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
   const formattedPublicKey = formatPublicKey({
     key: publicKey,
   });
+  const [isStatusTooltipOpen, setIsStatusTooltipOpen] = useState(false);
   const displayEmoji = extractEmojiFromStatus(status || '', emoji);
+  const parsedStatus = parseStatus(status || '', displayEmoji);
   const followersLabel = stats ? `${compactNumber.format(stats.followers)} FOLLOWERS` : null;
   const getLoadingFollowText = () => {
     if (followLoadingAction === FOLLOW_ACTIONS.UNFOLLOW) {
@@ -94,27 +97,6 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
       {formattedPublicKey}
     </Button>
   );
-  const renderStatusDisplay = () => {
-    if (!status || isOwnProfile) {
-      return null;
-    }
-
-    // For predefined statuses parseStatus already resolves `text` from STATUS_LABELS,
-    // which carries the same copy the status.* translation keys held.
-    const parsedStatus = parseStatus(status, displayEmoji);
-    const statusText = parsedStatus.text;
-
-    return (
-      <Container overrideDefaults={true} className="flex h-8 items-center gap-1">
-        <Typography as="span" overrideDefaults className="text-base leading-6">
-          {displayEmoji}
-        </Typography>
-        <Typography as="span" overrideDefaults className="text-base leading-6 font-bold text-white">
-          {statusText}
-        </Typography>
-      </Container>
-    );
-  };
 
   return (
     <Container
@@ -136,25 +118,54 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
           fallbackClassName="text-2xl lg:text-4xl"
           alt={name}
         />
-        <AvatarEmojiBadge emoji={displayEmoji} />
       </Container>
 
       {/* Mobile uses display: contents so children participate in the parent grid; desktop restores a normal flex column. */}
-      <Container overrideDefaults={true} className="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-3">
+      <Container overrideDefaults={true} className="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-0">
         <Container
           overrideDefaults={true}
           className={cn(
             'col-start-2 row-start-1 flex min-w-0 flex-col items-start gap-1 self-center lg:col-auto lg:row-auto lg:self-auto lg:text-left',
           )}
         >
-          <Typography
-            data-cy="profile-username-header"
-            as="h1"
-            size="lg"
-            className="max-width-profile-page-header w-full truncate text-2xl leading-normal text-white sm:max-w-xl lg:max-w-full lg:text-6xl"
+          <Container
+            overrideDefaults
+            className="max-width-profile-page-header flex w-fit min-w-0 items-center gap-2 sm:max-w-xl lg:max-w-full lg:gap-3"
           >
-            {name}
-          </Typography>
+            <Typography
+              data-cy="profile-username-header"
+              as="h1"
+              size="lg"
+              className="min-w-0 truncate text-2xl leading-normal text-white lg:text-6xl"
+            >
+              {name}
+            </Typography>
+            {displayEmoji && (
+              <Tooltip open={isStatusTooltipOpen} onOpenChange={setIsStatusTooltipOpen}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={`${parsedStatus.text} status`}
+                    className="shrink-0 rounded-sm border-0 bg-transparent p-0 text-2xl leading-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none lg:text-5xl"
+                    onPointerDown={(event) => {
+                      if (event.pointerType !== 'touch') return;
+
+                      event.preventDefault();
+                      setIsStatusTooltipOpen((open) => !open);
+                    }}
+                    onClick={(event) => event.preventDefault()}
+                  >
+                    {displayEmoji}
+                  </button>
+                </TooltipTrigger>
+                <TooltipPortal>
+                  <TooltipContent className="bg-accent font-medium text-foreground [&_svg]:fill-accent">
+                    {parsedStatus.text}
+                  </TooltipContent>
+                </TooltipPortal>
+              </Tooltip>
+            )}
+          </Container>
           <Container overrideDefaults className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 lg:hidden">
             <Container overrideDefaults className="flex min-w-0 items-center gap-1">
               <KeyRound className="size-4 shrink-0 text-muted-foreground" />
@@ -189,7 +200,7 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
 
         <Container
           overrideDefaults={true}
-          className="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:flex lg:flex-wrap lg:gap-3"
+          className="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:mt-3 lg:flex lg:flex-wrap lg:gap-3"
         >
           {/* Own profile actions */}
           {isOwnProfile && (
@@ -236,7 +247,7 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
               </Button>
               <Container
                 overrideDefaults
-                className="order-first col-span-2 flex h-8 items-center lg:order-0 lg:col-auto"
+                className="order-last col-span-2 flex h-8 items-center lg:order-0 lg:col-auto"
               >
                 <StatusPickerWrapper emoji={displayEmoji} status={status || ''} onStatusChange={onStatusChange} />
               </Container>
@@ -294,8 +305,6 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
                   </Button>
                 }
               />
-              {/* Status display inline with buttons */}
-              {renderStatusDisplay()}
             </>
           )}
         </Container>

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
@@ -19,7 +19,7 @@ import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/atoms/
 import { Typography } from '@/atoms/Typography/Typography';
 import { FOLLOW_ACTIONS } from '@/hooks/useFollowUser/useFollowUser.types';
 import { useTtlSubscription } from '@/hooks/useTtlSubscription/useTtlSubscription';
-import { extractEmojiFromStatus, parseStatus } from '@/libs/status/status';
+import { parseStatus } from '@/libs/status/status';
 import { cn, formatPublicKey } from '@/libs/utils/utils';
 import { PostText } from '@/molecules/PostText/PostText';
 import { StatusPickerWrapper } from '@/molecules/StatusPicker/StatusPickerWrapper/StatusPickerWrapper';
@@ -71,8 +71,8 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
     key: publicKey,
   });
   const [isStatusTooltipOpen, setIsStatusTooltipOpen] = useState(false);
-  const displayEmoji = extractEmojiFromStatus(status || '', emoji);
-  const parsedStatus = parseStatus(status || '', displayEmoji);
+  const parsedStatus = parseStatus(status || '', emoji);
+  const displayEmoji = parsedStatus.emoji;
   const followersLabel = stats ? `${compactNumber.format(stats.followers)} FOLLOWERS` : null;
   const getLoadingFollowText = () => {
     if (followLoadingAction === FOLLOW_ACTIONS.UNFOLLOW) {

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
@@ -121,7 +121,7 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
       </Container>
 
       {/* Mobile uses display: contents so children participate in the parent grid; desktop restores a normal flex column. */}
-      <Container overrideDefaults={true} className="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-0">
+      <Container overrideDefaults={true} className="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:gap-3">
         <Container
           overrideDefaults={true}
           className={cn(
@@ -136,7 +136,7 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
               data-cy="profile-username-header"
               as="h1"
               size="lg"
-              className="min-w-0 truncate text-2xl leading-normal text-white lg:text-6xl"
+              className="min-w-0 truncate text-2xl leading-8 text-white lg:text-6xl lg:leading-none"
             >
               {name}
             </Typography>
@@ -200,7 +200,7 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
 
         <Container
           overrideDefaults={true}
-          className="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:mt-3 lg:flex lg:flex-wrap lg:gap-3"
+          className="col-span-full grid w-full grid-cols-2 items-center gap-2 lg:col-auto lg:flex lg:flex-wrap lg:gap-3"
         >
           {/* Own profile actions */}
           {isOwnProfile && (

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx
@@ -53,7 +53,7 @@ vi.mock('@/hooks/useViewportObserver/useViewportObserver', () => ({
 }));
 
 vi.mock('@/hooks/useUserDetails/useUserDetails', () => ({
-  useUserDetails: () => ({ userDetails: { id: 'author', name: 'Author', image: null } }),
+  useUserDetails: () => ({ userDetails: { id: 'author', name: 'Author', image: null, status: 'vacationing' } }),
 }));
 
 vi.mock('@/hooks/useAvatarUrl/useAvatarUrl', () => ({
@@ -828,6 +828,7 @@ describe('VisualTimelinePosts', () => {
       expect.objectContaining({
         userId: 'author',
         userName: 'Author',
+        status: 'vacationing',
         avatarUrl: null,
       }),
       undefined,

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.tsx
@@ -161,7 +161,12 @@ function VisualTimelineTileOverlay({ tile, size, onReplyClick, onRepostClick }: 
           <Container overrideDefaults className="flex items-start justify-between gap-4">
             <Container overrideDefaults className="min-w-0 flex-1">
               {userDetails ? (
-                <PostHeaderUserInfo userId={userId} userName={userDetails.name || ''} avatarUrl={avatarUrl} />
+                <PostHeaderUserInfo
+                  userId={userId}
+                  userName={userDetails.name || ''}
+                  status={userDetails.status}
+                  avatarUrl={avatarUrl}
+                />
               ) : (
                 <Container overrideDefaults className="flex items-center gap-2">
                   <Skeleton className="size-6 rounded-full bg-white/20" />

--- a/src/libs/status/status.constants.ts
+++ b/src/libs/status/status.constants.ts
@@ -24,7 +24,7 @@ export const STATUS_EMOJIS = {
   traveling: '✈️',
   celebrating: '🥂',
   sick: '🤒',
-  noStatus: '💭',
+  noStatus: '',
   loading: '⏳',
 } as const;
 

--- a/src/libs/status/status.test.ts
+++ b/src/libs/status/status.test.ts
@@ -40,19 +40,19 @@ describe('status', () => {
         expect(STATUS_EMOJIS.traveling).toBe('✈️');
         expect(STATUS_EMOJIS.celebrating).toBe('🥂');
         expect(STATUS_EMOJIS.sick).toBe('🤒');
-        expect(STATUS_EMOJIS.noStatus).toBe('💭');
+        expect(STATUS_EMOJIS.noStatus).toBe('');
         expect(STATUS_EMOJIS.loading).toBe('⏳');
       });
 
-      it('should have all emojis as non-empty strings', () => {
+      it('should have all status emoji values as strings', () => {
         Object.values(STATUS_EMOJIS).forEach((emoji) => {
           expect(typeof emoji).toBe('string');
-          expect(emoji.length).toBeGreaterThan(0);
         });
       });
 
       it('should have emojis that match Unicode emoji pattern', () => {
-        Object.values(STATUS_EMOJIS).forEach((emoji) => {
+        Object.entries(STATUS_EMOJIS).forEach(([status, emoji]) => {
+          if (status === 'noStatus') return;
           expect(emoji).toMatch(/\p{Extended_Pictographic}/u);
         });
       });
@@ -368,12 +368,12 @@ describe('status', () => {
 
   describe('extractEmojiFromStatus', () => {
     describe('empty status', () => {
-      it('should return noStatus emoji for empty string', () => {
+      it('should return no emoji for empty string', () => {
         const result = extractEmojiFromStatus('');
         expect(result).toBe(STATUS_EMOJIS.noStatus);
       });
 
-      it('should return noStatus emoji for empty string with custom default', () => {
+      it('should return no emoji for empty string with custom default', () => {
         const result = extractEmojiFromStatus('', '🎯');
         expect(result).toBe(STATUS_EMOJIS.noStatus);
       });

--- a/src/libs/status/status.ts
+++ b/src/libs/status/status.ts
@@ -61,7 +61,7 @@ export function parseStatus(status: string, defaultEmoji: string = STATUS_EMOJIS
 
   if (isPredefined) {
     return {
-      emoji: STATUS_EMOJIS[statusKey] || defaultEmoji,
+      emoji: STATUS_EMOJIS[statusKey] ?? defaultEmoji,
       text: STATUS_LABELS[statusKey],
       isCustom: false,
       key: statusKey,
@@ -112,7 +112,7 @@ export function extractEmojiFromStatus(status: string, defaultEmoji: string = ST
   const isPredefined = statusKey in STATUS_LABELS;
 
   if (isPredefined) {
-    return STATUS_EMOJIS[statusKey] || defaultEmoji;
+    return STATUS_EMOJIS[statusKey] ?? defaultEmoji;
   }
 
   // Text-only custom status - use fallback emoji for display purposes


### PR DESCRIPTION
## Summary

- Show user status emojis inline after names in post headers, visual timelines, and profile headers.
- Hide the emoji for No Status, remove duplicate profile status rendering, and align No Status in the picker with an empty bordered circle.
- Add accessible status-label tooltips for hover, keyboard focus, and touch, using accent/foreground styling.
- Place the profile status picker below the mobile action buttons while preserving the desktop layout and mobile profile spacing.

## Validation

- 236 focused unit tests passed across 6 files
- TypeScript passed
- ESLint passed
- Prettier passed
- `git diff --check` passed


## Before (post user)
<img width="224" height="94" alt="image" src="https://github.com/user-attachments/assets/cd616957-343d-4bb3-9a41-a30a016824e1" />

## After (post user)
<img width="196" height="98" alt="image" src="https://github.com/user-attachments/assets/2ab1a5e0-c702-4b61-8f92-8c6f9fa77b56" />

Hover on desktop or tap on mobile: 
<img width="211" height="98" alt="image" src="https://github.com/user-attachments/assets/f6ca58db-651b-4dcc-afc0-896875e6aade" />

## Before (profile)
<img width="741" height="187" alt="image" src="https://github.com/user-attachments/assets/962ea4e9-01ff-4470-94ee-ec361b8d239f" />

## After (profile)
<img width="611" height="194" alt="image" src="https://github.com/user-attachments/assets/836bec53-3ef0-473c-be58-aff73f196dea" />

## Before (status picker)
<img width="303" height="409" alt="image" src="https://github.com/user-attachments/assets/7ded5966-b7a1-4ccd-9085-f38c42d84b0c" />

## After (status picker)
<img width="298" height="414" alt="image" src="https://github.com/user-attachments/assets/fff769b9-686c-41a1-90a7-a0e969b4e100" />