### PR TITLE
fix(ui): add paste button to collection add-post URL field

### DIFF
--- a/src/components/molecules/ControlledInputField/ControlledInputField.test.tsx
+++ b/src/components/molecules/ControlledInputField/ControlledInputField.test.tsx
@@ -76,6 +76,29 @@ describe('ControlledInputField', () => {
     expect(handlePaste).toHaveBeenCalled();
   });
 
+  it('forwards icon clicks', () => {
+    const handleClickIcon = vi.fn();
+
+    render(
+      <TestWrapper>
+        {(form) => (
+          <ControlledInputField<TestFormData>
+            name="testField"
+            control={form.control}
+            placeholder="Enter value"
+            icon={<span>icon</span>}
+            iconPosition="right"
+            onClickIcon={handleClickIcon}
+          />
+        )}
+      </TestWrapper>,
+    );
+
+    fireEvent.click(screen.getByText('icon'));
+
+    expect(handleClickIcon).toHaveBeenCalledTimes(1);
+  });
+
   it('renders without a label wrapper', () => {
     render(
       <TestWrapper>

--- a/src/components/molecules/ControlledInputField/ControlledInputField.test.tsx
+++ b/src/components/molecules/ControlledInputField/ControlledInputField.test.tsx
@@ -76,7 +76,7 @@ describe('ControlledInputField', () => {
     expect(handlePaste).toHaveBeenCalled();
   });
 
-  it('forwards icon clicks', () => {
+  it('forwards icon clicks through an accessible icon button', () => {
     const handleClickIcon = vi.fn();
 
     render(
@@ -89,12 +89,13 @@ describe('ControlledInputField', () => {
             icon={<span>icon</span>}
             iconPosition="right"
             onClickIcon={handleClickIcon}
+            iconAriaLabel="Icon action"
           />
         )}
       </TestWrapper>,
     );
 
-    fireEvent.click(screen.getByText('icon'));
+    fireEvent.click(screen.getByRole('button', { name: 'Icon action' }));
 
     expect(handleClickIcon).toHaveBeenCalledTimes(1);
   });

--- a/src/components/molecules/ControlledInputField/ControlledInputField.tsx
+++ b/src/components/molecules/ControlledInputField/ControlledInputField.tsx
@@ -18,6 +18,8 @@ export function ControlledInputField<T extends FieldValues>({
   size = 'lg',
   icon,
   iconPosition,
+  iconClassName,
+  onClickIcon,
   disabled = false,
   loading = false,
   loadingText,
@@ -43,6 +45,8 @@ export function ControlledInputField<T extends FieldValues>({
           size={size}
           icon={icon}
           iconPosition={iconPosition}
+          iconClassName={iconClassName}
+          onClickIcon={onClickIcon}
           disabled={disabled}
           loading={loading}
           loadingText={loadingText}

--- a/src/components/molecules/ControlledInputField/ControlledInputField.tsx
+++ b/src/components/molecules/ControlledInputField/ControlledInputField.tsx
@@ -20,6 +20,7 @@ export function ControlledInputField<T extends FieldValues>({
   iconPosition,
   iconClassName,
   onClickIcon,
+  iconAriaLabel,
   disabled = false,
   loading = false,
   loadingText,
@@ -47,6 +48,7 @@ export function ControlledInputField<T extends FieldValues>({
           iconPosition={iconPosition}
           iconClassName={iconClassName}
           onClickIcon={onClickIcon}
+          iconAriaLabel={iconAriaLabel}
           disabled={disabled}
           loading={loading}
           loadingText={loadingText}

--- a/src/components/molecules/ControlledInputField/ControlledInputField.types.ts
+++ b/src/components/molecules/ControlledInputField/ControlledInputField.types.ts
@@ -24,8 +24,10 @@ export interface ControlledInputFieldProps<T extends FieldValues> {
   iconPosition?: 'left' | 'right';
   /** Optional class applied to the icon wrapper */
   iconClassName?: string;
-  /** Optional click handler for the icon */
+  /** Optional click handler for the icon; renders the icon as an accessible button */
   onClickIcon?: () => void;
+  /** Accessible name for the icon button when onClickIcon is set */
+  iconAriaLabel?: string;
   /** Disabled state */
   disabled?: boolean;
   /** Loading state */

--- a/src/components/molecules/ControlledInputField/ControlledInputField.types.ts
+++ b/src/components/molecules/ControlledInputField/ControlledInputField.types.ts
@@ -22,6 +22,10 @@ export interface ControlledInputFieldProps<T extends FieldValues> {
   icon?: ReactNode;
   /** Icon position */
   iconPosition?: 'left' | 'right';
+  /** Optional class applied to the icon wrapper */
+  iconClassName?: string;
+  /** Optional click handler for the icon */
+  onClickIcon?: () => void;
   /** Disabled state */
   disabled?: boolean;
   /** Loading state */

--- a/src/components/molecules/InputField/InputField.test.tsx
+++ b/src/components/molecules/InputField/InputField.test.tsx
@@ -28,7 +28,7 @@ describe('InputField', () => {
     expect(handleClick).toHaveBeenCalled();
   });
 
-  it('invokes onClickIcon for a right-aligned icon', () => {
+  it('renders a clickable icon as an accessible button', () => {
     const handleClickIcon = vi.fn();
     render(
       <InputField
@@ -36,13 +36,43 @@ describe('InputField', () => {
         icon={<span>icon</span>}
         iconPosition="right"
         onClickIcon={handleClickIcon}
+        iconAriaLabel="Paste"
         iconClassName="mr-0"
       />,
     );
 
-    fireEvent.click(screen.getByText('icon'));
+    fireEvent.click(screen.getByRole('button', { name: 'Paste' }));
 
     expect(handleClickIcon).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a clickable icon mounted but inert while loading', () => {
+    const handleClickIcon = vi.fn();
+    render(
+      <InputField
+        value="test"
+        loading={true}
+        icon={<span>icon</span>}
+        iconPosition="right"
+        onClickIcon={handleClickIcon}
+        iconAriaLabel="Paste"
+      />,
+    );
+
+    const iconButton = screen.getByRole('button', { name: 'Paste' });
+    expect(iconButton).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(iconButton);
+
+    expect(handleClickIcon).not.toHaveBeenCalled();
+  });
+
+  it('associates the message with the input and announces errors', () => {
+    render(<InputField id="url" value="test" message="Enter a valid post URL." messageType="error" status="error" />);
+
+    const message = screen.getByRole('alert');
+    expect(message).toHaveTextContent('Enter a valid post URL.');
+    expect(screen.getByTestId('input')).toHaveAttribute('aria-describedby', 'url-message');
   });
 
   it('handles paste events', () => {

--- a/src/components/molecules/InputField/InputField.test.tsx
+++ b/src/components/molecules/InputField/InputField.test.tsx
@@ -28,6 +28,23 @@ describe('InputField', () => {
     expect(handleClick).toHaveBeenCalled();
   });
 
+  it('invokes onClickIcon for a right-aligned icon', () => {
+    const handleClickIcon = vi.fn();
+    render(
+      <InputField
+        value="test"
+        icon={<span>icon</span>}
+        iconPosition="right"
+        onClickIcon={handleClickIcon}
+        iconClassName="mr-0"
+      />,
+    );
+
+    fireEvent.click(screen.getByText('icon'));
+
+    expect(handleClickIcon).toHaveBeenCalledTimes(1);
+  });
+
   it('handles paste events', () => {
     const handlePaste = vi.fn();
     render(<InputField value="test" onPaste={handlePaste} />);

--- a/src/components/molecules/InputField/InputField.test.tsx.snap
+++ b/src/components/molecules/InputField/InputField.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`InputField - Snapshots > matches snapshot when not loading with icon 1`
   data-testid="container"
 >
   <div
-    class="mx-auto flex-col flex w-auto cursor-pointer items-center justify-center"
+    class="mx-auto flex-col flex w-auto items-center justify-center"
     data-testid="container"
   >
     <div
@@ -134,7 +134,7 @@ exports[`InputField - Snapshots > matches snapshot with icon 1`] = `
   data-testid="container"
 >
   <div
-    class="mx-auto flex-col flex w-auto cursor-pointer items-center justify-center"
+    class="mx-auto flex-col flex w-auto items-center justify-center"
     data-testid="container"
   >
     <div

--- a/src/components/molecules/InputField/InputField.tsx
+++ b/src/components/molecules/InputField/InputField.tsx
@@ -29,6 +29,7 @@ interface InputFieldProps {
   onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
   maxLength?: number;
   iconPosition?: 'left' | 'right';
+  iconClassName?: React.HTMLAttributes<HTMLDivElement>['className'];
   message?: ReactNode;
   messageType?: 'default' | 'info' | 'alert' | 'error' | 'success';
   size?: 'sm' | 'md' | 'lg';
@@ -43,7 +44,7 @@ export function InputField({
   disabled = false,
   readOnly = false,
   onClick,
-  onClickIcon = () => {},
+  onClickIcon,
   className,
   icon,
   variant = 'default',
@@ -57,6 +58,7 @@ export function InputField({
   onPaste,
   maxLength,
   iconPosition = 'left',
+  iconClassName,
   message,
   messageType = 'default',
   size = 'md',
@@ -103,7 +105,10 @@ export function InputField({
           </Container>
         )}
         {!loading && icon && iconPosition === 'left' && (
-          <Container onClick={onClickIcon} className={cn('w-auto cursor-pointer items-center justify-center')}>
+          <Container
+            onClick={onClickIcon}
+            className={cn('w-auto cursor-pointer items-center justify-center', iconClassName)}
+          >
             {icon}
           </Container>
         )}
@@ -126,7 +131,10 @@ export function InputField({
           data-cy={dataCy}
         />
         {!loading && icon && iconPosition === 'right' && (
-          <Container onClick={onClickIcon} className={cn('mr-5 w-auto cursor-pointer items-center justify-center')}>
+          <Container
+            onClick={onClickIcon}
+            className={cn('mr-5 w-auto cursor-pointer items-center justify-center', iconClassName)}
+          >
             {icon}
           </Container>
         )}

--- a/src/components/molecules/InputField/InputField.tsx
+++ b/src/components/molecules/InputField/InputField.tsx
@@ -16,6 +16,7 @@ interface InputFieldProps {
   readOnly?: boolean;
   onClick?: () => void;
   onClickIcon?: () => void;
+  iconAriaLabel?: string;
   className?: React.HTMLAttributes<HTMLDivElement>['className'];
   icon?: ReactNode;
   variant?: 'default' | 'dashed';
@@ -45,6 +46,7 @@ export function InputField({
   readOnly = false,
   onClick,
   onClickIcon,
+  iconAriaLabel,
   className,
   icon,
   variant = 'default',
@@ -84,6 +86,34 @@ export function InputField({
     error: 'text-red-500',
     success: 'text-brand',
   } as const;
+  const messageId = id && message ? `${id}-message` : undefined;
+  // An actionable icon renders as a real button (keyboard/screen-reader reachable) and stays mounted while
+  // loading — aria-disabled instead of disabled/unmount — so keyboard focus survives the pending state.
+  const iconSlot =
+    icon &&
+    (onClickIcon ? (
+      <button
+        type="button"
+        aria-label={iconAriaLabel}
+        aria-disabled={loading}
+        onClick={loading ? undefined : onClickIcon}
+        className={cn(
+          'flex w-auto cursor-pointer items-center justify-center outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-disabled:cursor-default aria-disabled:opacity-50',
+          iconPosition === 'right' && 'mr-5',
+          iconClassName,
+        )}
+      >
+        {icon}
+      </button>
+    ) : (
+      !loading && (
+        <Container
+          className={cn('w-auto items-center justify-center', iconPosition === 'right' && 'mr-5', iconClassName)}
+        >
+          {icon}
+        </Container>
+      )
+    ));
   return (
     <>
       <Container
@@ -104,14 +134,7 @@ export function InputField({
             )}
           </Container>
         )}
-        {!loading && icon && iconPosition === 'left' && (
-          <Container
-            onClick={onClickIcon}
-            className={cn('w-auto cursor-pointer items-center justify-center', iconClassName)}
-          >
-            {icon}
-          </Container>
-        )}
+        {iconPosition === 'left' && iconSlot}
         <Input
           id={id}
           name={name}
@@ -128,19 +151,19 @@ export function InputField({
           onPaste={onPaste}
           maxLength={maxLength}
           aria-invalid={status === 'error'}
+          aria-describedby={messageId}
           data-cy={dataCy}
         />
-        {!loading && icon && iconPosition === 'right' && (
-          <Container
-            onClick={onClickIcon}
-            className={cn('mr-5 w-auto cursor-pointer items-center justify-center', iconClassName)}
-          >
-            {icon}
-          </Container>
-        )}
+        {iconPosition === 'right' && iconSlot}
       </Container>
       {message && (
-        <Typography as="small" size="sm" className={cn('ml-1', messageClasses[messageType])}>
+        <Typography
+          as="small"
+          size="sm"
+          id={messageId}
+          role={messageType === 'error' ? 'alert' : undefined}
+          className={cn('ml-1', messageClasses[messageType])}
+        >
           {message}
         </Typography>
       )}

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DialogAddContent } from './DialogAddContent';
 
 const AUTHOR = 'a'.repeat(52);
@@ -153,6 +153,10 @@ describe('DialogAddContent', () => {
     mocks.prependOptimisticPosts.mockReturnValue(undefined);
   });
 
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, 'clipboard');
+  });
+
   it('renders the Content trigger', () => {
     render(<DialogAddContent />);
 
@@ -216,7 +220,6 @@ describe('DialogAddContent', () => {
     expect(screen.getByText("What's on your mind?")).toBeInTheDocument();
     expect(screen.getByPlaceholderText('https://')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Paste' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Paste' })).toHaveAttribute('data-cy', 'add-content-paste-button');
   });
 
   it.each(['add-content-feed-reply-pill', 'add-content-feed-repost-pill', 'add-content-feed-save-pill'])(
@@ -373,7 +376,7 @@ describe('DialogAddContent', () => {
       const input = screen.getByDisplayValue('Adding...');
       expect(input).toBeDisabled();
       expect(input.closest('[data-testid="container"]')).toHaveClass('gap-3');
-      expect(screen.queryByRole('button', { name: 'Paste' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Paste' })).toHaveAttribute('aria-disabled', 'true');
     });
 
     resolvePost(livePost());

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx
@@ -71,6 +71,7 @@ vi.mock('@/hooks/useAvatarUrl/useAvatarUrl', () => ({
 }));
 
 vi.mock('@/molecules/Toaster/use-toast', () => ({
+  toast: mocks.toast,
   useToast: () => ({ toast: mocks.toast }),
 }));
 
@@ -214,6 +215,8 @@ describe('DialogAddContent', () => {
     expect(screen.getByText('Create new post')).toBeInTheDocument();
     expect(screen.getByText("What's on your mind?")).toBeInTheDocument();
     expect(screen.getByPlaceholderText('https://')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Paste' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Paste' })).toHaveAttribute('data-cy', 'add-content-paste-button');
   });
 
   it.each(['add-content-feed-reply-pill', 'add-content-feed-repost-pill', 'add-content-feed-save-pill'])(
@@ -314,6 +317,45 @@ describe('DialogAddContent', () => {
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 
+  it('adds clipboard content when the paste button is clicked', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { readText: vi.fn().mockResolvedValue(POST_URL) },
+    });
+
+    render(<DialogAddContent />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Post' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Paste' }));
+
+    await waitFor(() =>
+      expect(mocks.commitCreateBookmark).toHaveBeenCalledWith({ postId: COMPOSITE_ID, userId: VIEWER }),
+    );
+    expect(mocks.prependOptimisticPosts).toHaveBeenCalledWith(COMPOSITE_ID);
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('shows an error toast when the paste button cannot read the clipboard', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { readText: vi.fn().mockRejectedValue(new Error('denied')) },
+    });
+
+    render(<DialogAddContent />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Post' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Paste' }));
+
+    await waitFor(() =>
+      expect(mocks.toast).toHaveBeenCalledWith({
+        variant: 'error',
+        description: 'Could not read clipboard.',
+      }),
+    );
+    expect(mocks.commitCreateBookmark).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
   it('disables the input and shows loading text while paste processing is pending', async () => {
     let resolvePost!: (value: ReturnType<typeof livePost>) => void;
     mocks.getOrFetchPost.mockReturnValue(new Promise((resolve) => (resolvePost = resolve)));
@@ -330,7 +372,8 @@ describe('DialogAddContent', () => {
     await waitFor(() => {
       const input = screen.getByDisplayValue('Adding...');
       expect(input).toBeDisabled();
-      expect(input.closest('[data-testid="container"]')).toHaveClass('gap-2');
+      expect(input.closest('[data-testid="container"]')).toHaveClass('gap-3');
+      expect(screen.queryByRole('button', { name: 'Paste' })).not.toBeInTheDocument();
     });
 
     resolvePost(livePost());

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx.snap
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx.snap
@@ -471,54 +471,46 @@ exports[`DialogAddContent - Snapshots > matches the opened desktop dialog snapsh
                   type="text"
                   value=""
                 />
-                <div
-                  class="mx-auto flex-col flex w-auto cursor-pointer items-center justify-center mr-0"
-                  data-testid="container"
+                <button
+                  aria-disabled="false"
+                  aria-label="Paste"
+                  class="flex cursor-pointer items-center justify-center outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-disabled:cursor-default aria-disabled:opacity-50 mr-0 size-6 shrink-0 rounded-full text-foreground hover:bg-accent/50 hover:text-accent-foreground"
+                  type="button"
                 >
-                  <button
-                    aria-label="Paste"
-                    class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border hover:text-accent-foreground hover:bg-accent/50 border-none size-6 shadow-none"
-                    data-cy="add-content-paste-button"
-                    data-size="icon"
-                    data-slot="button"
-                    data-variant="ghost"
-                    type="button"
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-clipboard-paste size-4"
+                    fill="none"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="lucide lucide-clipboard-paste size-4"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M11 14h10"
-                      />
-                      <path
-                        d="M16 4h2a2 2 0 0 1 2 2v1.344"
-                      />
-                      <path
-                        d="m17 18 4-4-4-4"
-                      />
-                      <path
-                        d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 1.793-1.113"
-                      />
-                      <rect
-                        height="4"
-                        rx="1"
-                        width="8"
-                        x="8"
-                        y="2"
-                      />
-                    </svg>
-                  </button>
-                </div>
+                    <path
+                      d="M11 14h10"
+                    />
+                    <path
+                      d="M16 4h2a2 2 0 0 1 2 2v1.344"
+                    />
+                    <path
+                      d="m17 18 4-4-4-4"
+                    />
+                    <path
+                      d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 1.793-1.113"
+                    />
+                    <rect
+                      height="4"
+                      rx="1"
+                      width="8"
+                      x="8"
+                      y="2"
+                    />
+                  </svg>
+                </button>
               </div>
             </div>
           </div>

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx.snap
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx.snap
@@ -457,7 +457,7 @@ exports[`DialogAddContent - Snapshots > matches the opened desktop dialog snapsh
               data-slot="card-footer"
             >
               <div
-                class="flex mx-0 w-full cursor-pointer flex-row items-center rounded-md border bg-transparent border-dashed text-base mb-0 h-auto gap-2 border-input bg-background/10! px-6 py-4 font-medium shadow-xs has-[input[aria-invalid=true]]:border-red-500"
+                class="flex mx-0 w-full cursor-pointer flex-row items-center rounded-md border bg-transparent border-dashed text-base mb-0 h-auto gap-3 border-input bg-background/10! px-6 py-4 font-medium shadow-xs has-[input[aria-invalid=true]]:border-red-500"
                 data-testid="container"
               >
                 <input
@@ -471,6 +471,54 @@ exports[`DialogAddContent - Snapshots > matches the opened desktop dialog snapsh
                   type="text"
                   value=""
                 />
+                <div
+                  class="mx-auto flex-col flex w-auto cursor-pointer items-center justify-center mr-0"
+                  data-testid="container"
+                >
+                  <button
+                    aria-label="Paste"
+                    class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border hover:text-accent-foreground hover:bg-accent/50 border-none size-6 shadow-none"
+                    data-cy="add-content-paste-button"
+                    data-size="icon"
+                    data-slot="button"
+                    data-variant="ghost"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-clipboard-paste size-4"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 14h10"
+                      />
+                      <path
+                        d="M16 4h2a2 2 0 0 1 2 2v1.344"
+                      />
+                      <path
+                        d="m17 18 4-4-4-4"
+                      />
+                      <path
+                        d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 1.793-1.113"
+                      />
+                      <rect
+                        height="4"
+                        rx="1"
+                        width="8"
+                        x="8"
+                        y="2"
+                      />
+                    </svg>
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.tsx
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.tsx
@@ -2,7 +2,7 @@
 
 import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef, type SyntheticEvent, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Library, MessageCircle, Plus, Repeat, SquarePlus } from 'lucide-react';
+import { ClipboardPaste, Library, MessageCircle, Plus, Repeat, SquarePlus } from 'lucide-react';
 import { APP_ROUTES } from '@/app/routes';
 import { Button } from '@/atoms/Button/Button';
 import { Card, CardFooter, CardHeader, CardTitle } from '@/atoms/Card/Card';
@@ -204,7 +204,22 @@ function UrlPasteCard({ addContentForm }: { addContentForm: ReturnType<typeof us
           loading={addContentForm.isPending}
           loadingText={'Adding...'}
           onPaste={addContentForm.handlePaste}
-          className="mb-0 h-auto gap-2 border-input bg-background/10! px-6 py-4 font-medium shadow-xs has-[input[aria-invalid=true]]:border-red-500"
+          icon={
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={'Paste'}
+              className="size-6 shadow-none"
+              data-cy="add-content-paste-button"
+              onClick={() => void addContentForm.pasteFromClipboard()}
+            >
+              <ClipboardPaste className="size-4" />
+            </Button>
+          }
+          iconPosition="right"
+          iconClassName="mr-0"
+          className="mb-0 h-auto gap-3 border-input bg-background/10! px-6 py-4 font-medium shadow-xs has-[input[aria-invalid=true]]:border-red-500"
           inputClassName="h-auto p-0 shadow-none"
           dataCy="add-content-url-input"
         />

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.tsx
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.tsx
@@ -204,21 +204,11 @@ function UrlPasteCard({ addContentForm }: { addContentForm: ReturnType<typeof us
           loading={addContentForm.isPending}
           loadingText={'Adding...'}
           onPaste={addContentForm.handlePaste}
-          icon={
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label={'Paste'}
-              className="size-6 shadow-none"
-              data-cy="add-content-paste-button"
-              onClick={() => void addContentForm.pasteFromClipboard()}
-            >
-              <ClipboardPaste className="size-4" />
-            </Button>
-          }
+          icon={<ClipboardPaste className="size-4" />}
           iconPosition="right"
-          iconClassName="mr-0"
+          iconAriaLabel="Paste"
+          onClickIcon={() => void addContentForm.pasteFromClipboard()}
+          iconClassName="mr-0 size-6 shrink-0 rounded-full text-foreground hover:bg-accent/50 hover:text-accent-foreground"
           className="mb-0 h-auto gap-3 border-input bg-background/10! px-6 py-4 font-medium shadow-xs has-[input[aria-invalid=true]]:border-red-500"
           inputClassName="h-auto p-0 shadow-none"
           dataCy="add-content-url-input"

--- a/src/hooks/useAddContentForm/useAddContentForm.test.ts
+++ b/src/hooks/useAddContentForm/useAddContentForm.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   getCollectionDetails: vi.fn(),
   commitUpdateCollectionItem: vi.fn(),
   onSuccess: vi.fn(),
+  toast: vi.fn(),
 }));
 vi.mock('@/controllers/bookmark/bookmark', () => ({
   BookmarkController: {
@@ -40,6 +41,10 @@ vi.mock('@/controllers/post/post', () => ({
 vi.mock('@/stores/auth/auth.store', () => ({
   useAuthStore: (selector: (state: { currentUserPubky: string | null }) => unknown) =>
     selector({ currentUserPubky: mocks.currentUserPubky }),
+}));
+
+vi.mock('@/molecules/Toaster/use-toast', () => ({
+  toast: mocks.toast,
 }));
 
 function livePost() {
@@ -296,5 +301,44 @@ describe('useAddContentForm', () => {
 
     await waitFor(() => expect(mocks.commitCreateBookmark).toHaveBeenCalled());
     expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('submits clipboard text from pasteFromClipboard', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { readText: vi.fn().mockResolvedValue(POST_URL) },
+    });
+
+    const { result } = renderHook(() =>
+      useAddContentForm({ target: { type: 'bookmarks' }, onSuccess: mocks.onSuccess }),
+    );
+
+    await act(async () => {
+      await result.current.pasteFromClipboard();
+    });
+
+    await waitFor(() => expect(mocks.commitCreateBookmark).toHaveBeenCalled());
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
+  it('toasts when pasteFromClipboard cannot read the clipboard', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { readText: vi.fn().mockRejectedValue(new Error('denied')) },
+    });
+
+    const { result } = renderHook(() =>
+      useAddContentForm({ target: { type: 'bookmarks' }, onSuccess: mocks.onSuccess }),
+    );
+
+    await act(async () => {
+      await result.current.pasteFromClipboard();
+    });
+
+    expect(mocks.commitCreateBookmark).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith({
+      variant: 'error',
+      description: 'Could not read clipboard.',
+    });
   });
 });

--- a/src/hooks/useAddContentForm/useAddContentForm.test.ts
+++ b/src/hooks/useAddContentForm/useAddContentForm.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ClipboardEvent } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { asInvalid } from '@/test-utils/type-assertions';
 import { useAddContentForm } from './useAddContentForm';
 import { ADD_CONTENT_FORM_FIELDS } from './useAddContentForm.types';
@@ -91,6 +91,11 @@ describe('useAddContentForm', () => {
     mocks.getCollectionDetails.mockResolvedValue(collectionDetails([]));
     mocks.commitUpdateCollectionItem.mockResolvedValue(undefined);
     mocks.onSuccess.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, 'clipboard');
+    Reflect.deleteProperty(navigator, 'permissions');
   });
 
   it('rejects invalid post references', async () => {
@@ -340,5 +345,122 @@ describe('useAddContentForm', () => {
       variant: 'error',
       description: 'Could not read clipboard.',
     });
+  });
+
+  it('explains how to unblock a denied clipboard permission', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { readText: vi.fn().mockRejectedValue(new Error('denied')) },
+    });
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: { query: vi.fn().mockResolvedValue({ state: 'denied' }) },
+    });
+
+    const { result } = renderHook(() =>
+      useAddContentForm({ target: { type: 'bookmarks' }, onSuccess: mocks.onSuccess }),
+    );
+
+    await act(async () => {
+      await result.current.pasteFromClipboard();
+    });
+
+    expect(mocks.commitCreateBookmark).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith({
+      variant: 'error',
+      description: "Clipboard access is blocked. Allow it in your browser's site settings, or paste manually.",
+    });
+  });
+
+  it('ignores a second paste click while the first is still reading', async () => {
+    let resolveRead!: (value: string) => void;
+    const readText = vi.fn(() => new Promise<string>((resolve) => (resolveRead = resolve)));
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { readText } });
+
+    const { result } = renderHook(() =>
+      useAddContentForm({ target: { type: 'bookmarks' }, onSuccess: mocks.onSuccess }),
+    );
+
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    await act(async () => {
+      first = result.current.pasteFromClipboard();
+      second = result.current.pasteFromClipboard();
+      resolveRead(POST_URL);
+      await Promise.all([first, second]);
+    });
+
+    expect(readText).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mocks.commitCreateBookmark).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not clobber text typed while the clipboard read is pending', async () => {
+    let resolveRead!: (value: string) => void;
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { readText: vi.fn(() => new Promise<string>((resolve) => (resolveRead = resolve))) },
+    });
+
+    const { result } = renderHook(() =>
+      useAddContentForm({ target: { type: 'bookmarks' }, onSuccess: mocks.onSuccess }),
+    );
+
+    let pastePromise!: Promise<void>;
+    await act(async () => {
+      pastePromise = result.current.pasteFromClipboard();
+      result.current.form.setValue(ADD_CONTENT_FORM_FIELDS.POST_URL, 'typed-while-waiting');
+      resolveRead(POST_URL);
+      await pastePromise;
+    });
+
+    expect(mocks.commitCreateBookmark).not.toHaveBeenCalled();
+    expect(result.current.form.getValues(ADD_CONTENT_FORM_FIELDS.POST_URL)).toBe('typed-while-waiting');
+  });
+
+  it('does not submit a clipboard read that resolves after unmount', async () => {
+    let resolveRead!: (value: string) => void;
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { readText: vi.fn(() => new Promise<string>((resolve) => (resolveRead = resolve))) },
+    });
+
+    const { result, unmount } = renderHook(() =>
+      useAddContentForm({ target: { type: 'bookmarks' }, onSuccess: mocks.onSuccess }),
+    );
+
+    let pastePromise!: Promise<void>;
+    act(() => {
+      pastePromise = result.current.pasteFromClipboard();
+    });
+    unmount();
+
+    await act(async () => {
+      resolveRead(POST_URL);
+      await pastePromise;
+    });
+
+    expect(mocks.commitCreateBookmark).not.toHaveBeenCalled();
+    expect(mocks.onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized pasted values without writing them into the form', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { readText: vi.fn().mockResolvedValue('x'.repeat(5000)) },
+    });
+
+    const { result } = renderHook(() =>
+      useAddContentForm({ target: { type: 'bookmarks' }, onSuccess: mocks.onSuccess }),
+    );
+
+    await act(async () => {
+      await result.current.pasteFromClipboard();
+    });
+
+    expect(mocks.commitCreateBookmark).not.toHaveBeenCalled();
+    expect(result.current.form.getValues(ADD_CONTENT_FORM_FIELDS.POST_URL)).toBe('');
+    expect(result.current.form.getFieldState(ADD_CONTENT_FORM_FIELDS.POST_URL).error?.message).toBe(
+      'Enter a valid post URL.',
+    );
   });
 });

--- a/src/hooks/useAddContentForm/useAddContentForm.ts
+++ b/src/hooks/useAddContentForm/useAddContentForm.ts
@@ -7,6 +7,7 @@ import { BookmarkController } from '@/controllers/bookmark/bookmark';
 import { PostController } from '@/controllers/post/post';
 import { Logger } from '@/libs/logger/logger';
 import { isPostDeleted } from '@/libs/utils/utils';
+import { toast } from '@/molecules/Toaster/use-toast';
 import { CollectionPostContent } from '@/pipes/post/post.collection';
 import { parsePostReference } from '@/pipes/post/post.reference';
 import { useAuthStore } from '@/stores/auth/auth.store';
@@ -27,6 +28,7 @@ interface UseAddContentFormResult {
   form: UseFormReturn<AddContentFormData>;
   submit: (value?: string) => Promise<boolean>;
   handlePaste: (event: React.ClipboardEvent<HTMLInputElement>) => void;
+  pasteFromClipboard: () => Promise<void>;
   reset: () => void;
   isPending: boolean;
 }
@@ -134,10 +136,27 @@ export function useAddContentForm({ target, onSuccess }: UseAddContentFormOption
     void submit(event.clipboardData.getData('text'));
   };
 
+  const pasteFromClipboard = async () => {
+    if (isPending) return;
+
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) {
+      toast({ variant: 'error', description: 'Could not read clipboard.' });
+      return;
+    }
+
+    try {
+      const text = await navigator.clipboard.readText();
+      await submit(text);
+    } catch {
+      toast({ variant: 'error', description: 'Could not read clipboard.' });
+    }
+  };
+
   return {
     form,
     submit,
     handlePaste,
+    pasteFromClipboard,
     reset,
     isPending,
   };

--- a/src/hooks/useAddContentForm/useAddContentForm.ts
+++ b/src/hooks/useAddContentForm/useAddContentForm.ts
@@ -1,12 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, type UseFormReturn } from 'react-hook-form';
 import { BookmarkController } from '@/controllers/bookmark/bookmark';
 import { PostController } from '@/controllers/post/post';
 import { Logger } from '@/libs/logger/logger';
-import { isPostDeleted } from '@/libs/utils/utils';
+import { isPostDeleted, readFromClipboard } from '@/libs/utils/utils';
 import { toast } from '@/molecules/Toaster/use-toast';
 import { CollectionPostContent } from '@/pipes/post/post.collection';
 import { parsePostReference } from '@/pipes/post/post.reference';
@@ -33,9 +33,23 @@ interface UseAddContentFormResult {
   isPending: boolean;
 }
 
+const MAX_POST_URL_LENGTH = 2048;
+
 export function useAddContentForm({ target, onSuccess }: UseAddContentFormOptions): UseAddContentFormResult {
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   const [isPending, setIsPending] = useState(false);
+  // Refs, not state: reentrancy guards must flip synchronously — the isPending state a render closure
+  // captures stays false until the re-render, letting rapid double-clicks start two submit pipelines.
+  const submitPendingRef = useRef(false);
+  const readingClipboardRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const form = useForm<AddContentFormData>({
     resolver: zodResolver(addContentFormSchema),
@@ -55,79 +69,92 @@ export function useAddContentForm({ target, onSuccess }: UseAddContentFormOption
   };
 
   const submit = async (value?: string): Promise<boolean> => {
-    if (isPending) return false;
-
-    if (value !== undefined) {
-      form.setValue(ADD_CONTENT_FORM_FIELDS.POST_URL, value, {
-        shouldDirty: true,
-        shouldValidate: false,
-      });
-    }
-
-    const isValid = await form.trigger(ADD_CONTENT_FORM_FIELDS.POST_URL);
-    if (!isValid) return false;
-
-    const parsed = parsePostReference(form.getValues(ADD_CONTENT_FORM_FIELDS.POST_URL));
-    if (!parsed) {
-      setFieldError('Enter a valid post URL.');
-      return false;
-    }
-
-    if (!currentUserPubky) {
-      setFieldError('Could not add this post.');
-      return false;
-    }
-
-    setIsPending(true);
+    if (submitPendingRef.current) return false;
+    submitPendingRef.current = true;
 
     try {
-      const post = await PostController.getOrFetch({
-        compositeId: parsed.compositeId,
-        viewerId: currentUserPubky,
-      });
+      if (value !== undefined) {
+        if (value.length > MAX_POST_URL_LENGTH) {
+          setFieldError('Enter a valid post URL.');
+          return false;
+        }
 
-      if (!post || isPostDeleted(post.content)) {
-        setFieldError('We could not find that post.');
-        return false;
-      }
-
-      if (post.kind === 'collection') {
-        setFieldError('Collection can not be added to a collection.');
-        return false;
-      }
-
-      const alreadyAdded = await isAlreadyAdded({ target, postId: parsed.compositeId, postUri: parsed.postUri });
-      if (alreadyAdded) {
-        setFieldError('This post is already added.');
-        return false;
-      }
-
-      if (target.type === 'bookmarks') {
-        await BookmarkController.commitCreate({
-          postId: parsed.compositeId,
-          userId: currentUserPubky,
-        });
-      } else {
-        await PostController.commitUpdateCollectionItem({
-          collectionId: target.collectionId,
-          postId: parsed.compositeId,
-          shouldAdd: true,
+        form.setValue(ADD_CONTENT_FORM_FIELDS.POST_URL, value, {
+          shouldDirty: true,
+          shouldValidate: false,
         });
       }
 
-      await onSuccess?.(parsed.compositeId);
-      reset();
-      return true;
-    } catch (error) {
-      Logger.error('[useAddContentForm] Failed to add content', {
-        error,
-        target,
-        postId: parsed.compositeId,
-      });
-      setFieldError('Could not add this post.');
-      return false;
+      const isValid = await form.trigger(ADD_CONTENT_FORM_FIELDS.POST_URL);
+      if (!isValid) return false;
+
+      const parsed = parsePostReference(form.getValues(ADD_CONTENT_FORM_FIELDS.POST_URL));
+      if (!parsed) {
+        setFieldError('Enter a valid post URL.');
+        return false;
+      }
+
+      if (!currentUserPubky) {
+        setFieldError('Could not add this post.');
+        return false;
+      }
+
+      setIsPending(true);
+
+      try {
+        const post = await PostController.getOrFetch({
+          compositeId: parsed.compositeId,
+          viewerId: currentUserPubky,
+        });
+
+        if (!post || isPostDeleted(post.content)) {
+          setFieldError('We could not find that post.');
+          return false;
+        }
+
+        if (post.kind === 'collection') {
+          setFieldError('Collection can not be added to a collection.');
+          return false;
+        }
+
+        const alreadyAdded = await isAlreadyAdded({ target, postId: parsed.compositeId, postUri: parsed.postUri });
+        if (alreadyAdded) {
+          setFieldError('This post is already added.');
+          return false;
+        }
+
+        // The awaits above give the user time to dismiss the dialog; never commit after it closed.
+        if (!mountedRef.current) return false;
+
+        if (target.type === 'bookmarks') {
+          await BookmarkController.commitCreate({
+            postId: parsed.compositeId,
+            userId: currentUserPubky,
+          });
+        } else {
+          await PostController.commitUpdateCollectionItem({
+            collectionId: target.collectionId,
+            postId: parsed.compositeId,
+            shouldAdd: true,
+          });
+        }
+
+        await onSuccess?.(parsed.compositeId);
+        reset();
+        return true;
+      } catch (error) {
+        Logger.error('[useAddContentForm] Failed to add content', {
+          error,
+          target,
+          postId: parsed.compositeId,
+        });
+        setFieldError('Could not add this post.');
+        return false;
+      } finally {
+        setIsPending(false);
+      }
     } finally {
-      setIsPending(false);
+      submitPendingRef.current = false;
     }
   };
 
@@ -137,19 +164,27 @@ export function useAddContentForm({ target, onSuccess }: UseAddContentFormOption
   };
 
   const pasteFromClipboard = async () => {
-    if (isPending) return;
+    if (readingClipboardRef.current || submitPendingRef.current) return;
+    readingClipboardRef.current = true;
 
-    if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) {
-      toast({ variant: 'error', description: 'Could not read clipboard.' });
-      return;
-    }
+    const valueBeforeRead = form.getValues(ADD_CONTENT_FORM_FIELDS.POST_URL);
 
+    let text: string;
     try {
-      const text = await navigator.clipboard.readText();
-      await submit(text);
-    } catch {
-      toast({ variant: 'error', description: 'Could not read clipboard.' });
+      text = await readFromClipboard();
+    } catch (error) {
+      Logger.error('[useAddContentForm] Failed to read clipboard', { error });
+      toast({ variant: 'error', description: await clipboardReadErrorDescription() });
+      return;
+    } finally {
+      readingClipboardRef.current = false;
     }
+
+    // The read can stall on a browser permission prompt: never act on a closed dialog,
+    // and never clobber text the user typed while waiting.
+    if (!mountedRef.current || form.getValues(ADD_CONTENT_FORM_FIELDS.POST_URL) !== valueBeforeRead) return;
+
+    await submit(text);
   };
 
   return {
@@ -160,6 +195,23 @@ export function useAddContentForm({ target, onSuccess }: UseAddContentFormOption
     reset,
     isPending,
   };
+}
+
+/**
+ * A denied clipboard-read permission is sticky in Chromium — the browser never re-prompts, so the
+ * user must reset it themselves. Detect that state to explain the way out instead of a dead-end error.
+ */
+async function clipboardReadErrorDescription(): Promise<string> {
+  try {
+    const status = await navigator.permissions.query({ name: 'clipboard-read' as PermissionName });
+    if (status.state === 'denied') {
+      return "Clipboard access is blocked. Allow it in your browser's site settings, or paste manually.";
+    }
+  } catch {
+    // Permissions API absent or 'clipboard-read' unsupported (Firefox/Safari) — use the generic message.
+  }
+
+  return 'Could not read clipboard.';
 }
 
 async function isAlreadyAdded({

--- a/src/libs/utils/utils.test.ts
+++ b/src/libs/utils/utils.test.ts
@@ -31,6 +31,7 @@ import {
   isValidTagLabel,
   minutesAgo,
   radixIdSerializer,
+  readFromClipboard,
   resolveDisplayName,
   sanitizeTagInput,
   shouldBypassLinkConfirmation,
@@ -419,6 +420,37 @@ describe('Utils', () => {
       });
 
       await expect(copyToClipboard({ text: 'test' })).rejects.toThrow('Fallback copy command was unsuccessful');
+    });
+  });
+
+  describe('readFromClipboard', () => {
+    afterEach(() => {
+      Object.defineProperty(navigator, 'clipboard', { value: undefined, writable: true });
+    });
+
+    it('should resolve with the clipboard text', async () => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { readText: vi.fn().mockResolvedValue('clipboard text') },
+        writable: true,
+      });
+
+      await expect(readFromClipboard()).resolves.toBe('clipboard text');
+    });
+
+    it('should throw when the Clipboard API is unavailable', async () => {
+      Object.defineProperty(navigator, 'clipboard', { value: undefined, writable: true });
+
+      await expect(readFromClipboard()).rejects.toThrow('Clipboard API not supported');
+    });
+
+    it('should propagate read rejections', async () => {
+      const denied = new Error('denied');
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { readText: vi.fn().mockRejectedValue(denied) },
+        writable: true,
+      });
+
+      await expect(readFromClipboard()).rejects.toThrow('denied');
     });
   });
 

--- a/src/libs/utils/utils.ts
+++ b/src/libs/utils/utils.ts
@@ -153,6 +153,18 @@ export async function copyToClipboard({ text }: CopyToClipboardProps) {
   }
 }
 
+/**
+ * Read text from the clipboard. Throws when the Clipboard API is unavailable
+ * (non-secure context, unsupported browser) or the read is denied.
+ */
+export async function readFromClipboard(): Promise<string> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) {
+    throw new Error('Clipboard API not supported');
+  }
+
+  return navigator.clipboard.readText();
+}
+
 const customCases = [
   { name: 'bitcoin', color: '#FF9900' },
   { name: 'synonym', color: '#FF6600' },


### PR DESCRIPTION
## Summary
- fix #2103
- Restore the v25 clipboard control on **Paste post url** in the Add Post dialog so users can add a post from the clipboard without relying on keyboard paste
- Desktop and mobile share this dialog, so one control covers both

## Changes
- Add a 24px ghost **Paste** button (`ClipboardPaste`) inside the dashed URL field
- Read the clipboard on click and reuse the existing add-to-collection submit path
- Toast when clipboard access is denied; keep `Cmd`/`Ctrl`+`V` paste working
- Forward `onClickIcon` / `iconClassName` through `ControlledInputField` so the trailing icon can sit flush in this field

https://github.com/user-attachments/assets/cb943e8b-cf67-4865-9291-324360cd733b

## Test plan
- [ ] Open Add Post on a collection (and bookmarks) and confirm the clipboard icon appears in the **Paste post url** field on desktop and mobile widths
- [ ] Click the paste button with a valid post URL on the clipboard and confirm the post is added and the dialog closes
- [ ] Deny clipboard permission (or empty clipboard API) and confirm an error toast; then paste with the keyboard and confirm that path still works
- [ ] Confirm an invalid pasted URL still shows the field error under the input

## Notes
- Design: [Figma — Dialog / Add Content](https://www.figma.com/design/01ZvjSPZnKTNmaEWz0yJsq/Pubky-SHADCN?node-id=41492-356218&m=dev)
- This dialog has no VRT baseline