### PR TITLE
fix(ui): restore original collection add-post options

### DIFF
--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx
@@ -212,7 +212,13 @@ describe('DialogAddContent', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Add Post' }));
 
-    expect(screen.getByRole('dialog')).toHaveClass('outline-none', 'focus:outline-none', 'focus-visible:outline-none');
+    expect(screen.getByRole('dialog')).toHaveClass(
+      'overflow-y-auto',
+      'outline-none',
+      'focus:outline-none',
+      'focus-visible:outline-none',
+    );
+    expect(screen.getByRole('dialog')).not.toHaveClass('overflow-hidden');
     expect(screen.getByTestId('dialog-title')).toHaveTextContent('Add Post');
     expect(screen.getByText('Choose how to add posts to your collection.')).toHaveClass('sm:hidden');
     expect(screen.getByText('There are several ways to add posts to your collection.')).toHaveClass(

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx
@@ -207,19 +207,55 @@ describe('DialogAddContent', () => {
     expect(trigger).not.toHaveClass('h-16');
   });
 
-  it('opens the desktop dialog with feed, URL, and create-post options', () => {
+  it('opens the dialog with the four add-post options in responsive grid order', () => {
     render(<DialogAddContent />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Add Post' }));
 
     expect(screen.getByRole('dialog')).toHaveClass('outline-none', 'focus:outline-none', 'focus-visible:outline-none');
     expect(screen.getByTestId('dialog-title')).toHaveTextContent('Add Post');
+    expect(screen.getByText('Choose how to add posts to your collection.')).toHaveClass('sm:hidden');
+    expect(screen.getByText('There are several ways to add posts to your collection.')).toHaveClass(
+      'hidden',
+      'sm:inline',
+    );
     expect(screen.getByText('Add from feed')).toBeInTheDocument();
+    expect(screen.getByText('Select from posts')).toBeInTheDocument();
     expect(screen.getByText('Paste post url')).toBeInTheDocument();
     expect(screen.getByText('Create new post')).toBeInTheDocument();
-    expect(screen.getByText("What's on your mind?")).toBeInTheDocument();
+    expect(screen.getByText('Start writing')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('https://')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Paste' })).toBeInTheDocument();
+
+    const options = document.querySelector('[data-cy="add-content-options"]');
+    expect(options).toHaveClass('grid', 'grid-cols-1', 'gap-3', 'sm:grid-cols-2');
+
+    const cards = options?.querySelectorAll('[data-slot="card"]');
+    expect(Array.from(cards ?? []).map((card) => card.querySelector('[data-slot="card-title"]')?.textContent)).toEqual([
+      'Add from feed',
+      'Select from posts',
+      'Paste post url',
+      'Create new post',
+    ]);
+  });
+
+  it('closes the dialog and navigates to profile posts without mutating content when Select is clicked', async () => {
+    render(<DialogAddContent target={{ type: 'collection', collectionId: COLLECTION_ID }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Post' }));
+
+    const selectButton = screen.getByRole('button', { name: 'Select' });
+    expect(selectButton).toHaveAttribute('data-cy', 'add-content-select-from-posts');
+    fireEvent.click(selectButton);
+
+    expect(mocks.routerPush).toHaveBeenCalledWith('/profile/posts');
+    expect(mocks.getOrFetchPost).not.toHaveBeenCalled();
+    expect(mocks.bookmarkExists).not.toHaveBeenCalled();
+    expect(mocks.commitCreateBookmark).not.toHaveBeenCalled();
+    expect(mocks.getCollectionDetails).not.toHaveBeenCalled();
+    expect(mocks.commitUpdateCollectionItem).not.toHaveBeenCalled();
+    expect(mocks.prependOptimisticPosts).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 
   it.each(['add-content-feed-reply-pill', 'add-content-feed-repost-pill', 'add-content-feed-save-pill'])(
@@ -409,7 +445,7 @@ describe('DialogAddContent', () => {
     render(<DialogAddContent target={{ type: 'collection', collectionId: COLLECTION_ID }} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Add Post' }));
-    fireEvent.click(screen.getByRole('button', { name: /What's on your mind?/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Start writing/ }));
 
     await waitFor(() => {
       expect(screen.getByRole('dialog', { name: 'new post' })).toBeInTheDocument();
@@ -421,7 +457,7 @@ describe('DialogAddContent', () => {
     render(<DialogAddContent target={{ type: 'collection', collectionId: COLLECTION_ID }} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Add Post' }));
-    fireEvent.click(screen.getByRole('button', { name: /What's on your mind?/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Start writing/ }));
     fireEvent.click(screen.getByRole('button', { name: 'create post success' }));
 
     await waitFor(() =>
@@ -443,7 +479,7 @@ describe('DialogAddContent', () => {
     render(<DialogAddContent />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Add Post' }));
-    fireEvent.click(screen.getByRole('button', { name: /What's on your mind?/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Start writing/ }));
     fireEvent.click(screen.getByRole('button', { name: 'create post success' }));
 
     await waitFor(() =>

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx.snap
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx.snap
@@ -297,11 +297,21 @@ exports[`DialogAddContent - Snapshots > matches the opened desktop dialog snapsh
             data-slot="dialog-description"
             id="radix-normalized"
           >
-            There are several ways to add posts to your collection.
+            <span
+              class="sm:hidden"
+            >
+              Choose how to add posts to your collection.
+            </span>
+            <span
+              class="hidden sm:inline"
+            >
+              There are several ways to add posts to your collection.
+            </span>
           </p>
         </div>
         <div
-          class="flex w-full flex-col gap-3"
+          class="grid w-full grid-cols-1 gap-3 sm:grid-cols-2"
+          data-cy="add-content-options"
           data-testid="container"
         >
           <div
@@ -449,6 +459,70 @@ exports[`DialogAddContent - Snapshots > matches the opened desktop dialog snapsh
                 class="text-base leading-none font-bold text-card-foreground"
                 data-slot="card-title"
               >
+                Select from posts
+              </div>
+            </div>
+            <div
+              class="px-6"
+              data-slot="card-content"
+            >
+              <button
+                class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-8 gap-1.5 px-3 has-[>svg]:px-3.5"
+                data-cy="add-content-select-from-posts"
+                data-size="sm"
+                data-slot="button"
+                data-variant="secondary"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="lucide lucide-list size-4"
+                  fill="none"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M3 5h.01"
+                  />
+                  <path
+                    d="M3 12h.01"
+                  />
+                  <path
+                    d="M3 19h.01"
+                  />
+                  <path
+                    d="M8 5h13"
+                  />
+                  <path
+                    d="M8 12h13"
+                  />
+                  <path
+                    d="M8 19h13"
+                  />
+                </svg>
+                Select
+              </button>
+            </div>
+          </div>
+          <div
+            class="flex flex-col bg-card text-card-foreground min-w-0 gap-4 overflow-hidden rounded-md py-6 shadow-sm"
+            data-slot="card"
+            data-testid="card"
+          >
+            <div
+              class="@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 px-6"
+              data-slot="card-header"
+            >
+              <div
+                class="text-base leading-none font-bold text-card-foreground"
+                data-slot="card-title"
+              >
                 Paste post url
               </div>
             </div>
@@ -535,13 +609,13 @@ exports[`DialogAddContent - Snapshots > matches the opened desktop dialog snapsh
               data-slot="card-footer"
             >
               <button
-                class="flex w-full cursor-pointer items-center gap-4 rounded-md border border-dashed border-input px-6 py-4 text-left outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                class="flex w-full cursor-pointer items-center gap-3 rounded-md border border-dashed border-input px-4 py-3 text-left outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
                 data-cy="add-content-create-post"
                 data-slot="button"
                 type="button"
               >
                 <span
-                  class="relative flex shrink-0 overflow-hidden rounded-full h-10 w-10"
+                  class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
                 >
                   <span
                     class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
@@ -607,7 +681,7 @@ exports[`DialogAddContent - Snapshots > matches the opened desktop dialog snapsh
                   class="min-w-0 flex-1 truncate text-base font-medium text-input"
                   data-testid="typography"
                 >
-                  What's on your mind?
+                  Start writing
                 </p>
               </button>
             </div>

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx.snap
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx.snap
@@ -260,7 +260,7 @@ exports[`DialogAddContent - Snapshots > matches the opened desktop dialog snapsh
   >
     <div
       aria-labelledby="radix-normalized"
-      class="relative z-50 duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 border p-6 sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b flex w-xl flex-col overflow-hidden border-border bg-popover shadow-2xl outline-none focus:outline-none focus-visible:outline-none"
+      class="relative z-50 duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border p-6 sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b flex w-xl flex-col border-border bg-popover shadow-2xl outline-none focus:outline-none focus-visible:outline-none"
       data-cy="dialog-content"
       data-slot="dialog-content"
       data-state="open"

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.tsx
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.tsx
@@ -367,7 +367,7 @@ export function DialogAddContent({
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogTrigger asChild>{trigger}</DialogTrigger>
         <DialogContent
-          className="flex w-xl flex-col overflow-hidden border-border bg-popover shadow-2xl outline-none focus:outline-none focus-visible:outline-none"
+          className="flex w-xl flex-col border-border bg-popover shadow-2xl outline-none focus:outline-none focus-visible:outline-none"
           hiddenTitle={'Add Post'}
         >
           <DialogAddContentBody

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.tsx
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.tsx
@@ -2,10 +2,10 @@
 
 import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef, type SyntheticEvent, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { ClipboardPaste, Library, MessageCircle, Plus, Repeat, SquarePlus } from 'lucide-react';
-import { APP_ROUTES } from '@/app/routes';
+import { ClipboardPaste, Library, List as ListIcon, MessageCircle, Plus, Repeat, SquarePlus } from 'lucide-react';
+import { APP_ROUTES, PROFILE_ROUTES } from '@/app/routes';
 import { Button } from '@/atoms/Button/Button';
-import { Card, CardFooter, CardHeader, CardTitle } from '@/atoms/Card/Card';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/atoms/Card/Card';
 import { Container } from '@/atoms/Container/Container';
 import {
   Dialog,
@@ -187,6 +187,28 @@ function FeedInstructionCard({ onOpenFeed }: { onOpenFeed: () => void }) {
   );
 }
 
+function SelectFromPostsCard({ onSelectFromPosts }: { onSelectFromPosts: () => void }) {
+  return (
+    <Card className="min-w-0 gap-4 overflow-hidden rounded-md py-6 shadow-sm">
+      <CardHeader className="px-6">
+        <CardTitle className="text-base leading-none font-bold text-card-foreground">{'Select from posts'}</CardTitle>
+      </CardHeader>
+      <CardContent className="px-6">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={onSelectFromPosts}
+          data-cy="add-content-select-from-posts"
+        >
+          <ListIcon className="size-4" />
+          {'Select'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
 function UrlPasteCard({ addContentForm }: { addContentForm: ReturnType<typeof useAddContentForm> }) {
   return (
     <Card className="min-w-0 gap-4 overflow-hidden rounded-md py-6 shadow-sm">
@@ -234,17 +256,17 @@ function CreatePostCard({ onCreatePost }: { onCreatePost: () => void }) {
           type="button"
           onClick={onCreatePost}
           data-cy="add-content-create-post"
-          className="flex w-full cursor-pointer items-center gap-4 rounded-md border border-dashed border-input px-6 py-4 text-left outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          className="flex w-full cursor-pointer items-center gap-3 rounded-md border border-dashed border-input px-4 py-3 text-left outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
         >
           <AvatarWithFallback
             avatarUrl={avatarUrl}
             name={displayName}
             fallbackSeed={currentUserPubky ?? displayName}
-            size="default"
+            size="md"
             alt={displayName}
           />
           <Typography overrideDefaults className="min-w-0 flex-1 truncate text-base font-medium text-input">
-            {"What's on your mind?"}
+            {'Start writing'}
           </Typography>
         </Button>
       </CardFooter>
@@ -257,11 +279,13 @@ function DialogAddContentBody({
   onSuccess,
   onCreatePost,
   onOpenFeed,
+  onSelectFromPosts,
 }: {
   target: NonNullable<DialogAddContentProps['target']>;
   onSuccess: (postId: string) => Promise<void>;
   onCreatePost: () => void;
   onOpenFeed: () => void;
+  onSelectFromPosts: () => void;
 }) {
   const addContentForm = useAddContentForm({
     target,
@@ -278,11 +302,17 @@ function DialogAddContentBody({
       <DialogHeader className="pr-0">
         <DialogTitle>{'Add Post'}</DialogTitle>
         <DialogDescription className="text-muted-foreground">
-          {'There are several ways to add posts to your collection.'}
+          <span className="sm:hidden">{'Choose how to add posts to your collection.'}</span>
+          <span className="hidden sm:inline">{'There are several ways to add posts to your collection.'}</span>
         </DialogDescription>
       </DialogHeader>
-      <Container overrideDefaults className="flex w-full flex-col gap-3">
+      <Container
+        overrideDefaults
+        data-cy="add-content-options"
+        className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2"
+      >
         <FeedInstructionCard onOpenFeed={onOpenFeed} />
+        <SelectFromPostsCard onSelectFromPosts={onSelectFromPosts} />
         <UrlPasteCard addContentForm={addContentForm} />
         <CreatePostCard onCreatePost={onCreatePost} />
       </Container>
@@ -317,6 +347,11 @@ export function DialogAddContent({
     router.push(APP_ROUTES.HOME);
   };
 
+  const handleSelectFromPosts = () => {
+    setOpen(false);
+    router.push(PROFILE_ROUTES.POSTS);
+  };
+
   const handlePostCreated = async (createdPostId: string) => {
     await saveCreatedPostToTarget({
       target,
@@ -340,6 +375,7 @@ export function DialogAddContent({
             onSuccess={handleSuccess}
             onCreatePost={handleCreatePost}
             onOpenFeed={handleOpenFeed}
+            onSelectFromPosts={handleSelectFromPosts}
           />
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
## Summary

- restore the original four-option Add Post dialog in a responsive one-column/two-column layout
- add Select from posts and route its Select action to /profile/posts without mutating collection content
- preserve Add from feed, paste URL including the clipboard button from #2381, and create-post behavior
- restore the original responsive descriptions and Start writing prompt

https://github.com/user-attachments/assets/32f4094b-984d-46cb-805a-09548ae08b51

https://github.com/user-attachments/assets/84566877-9d78-4c94-870a-d1685f116fc2

## Testing

- npm test -- src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx src/hooks/useAddContentForm/useAddContentForm.test.ts src/components/molecules/ControlledInputField/ControlledInputField.test.tsx src/components/molecules/InputField/InputField.test.tsx (60 passed)
- TypeScript typecheck
- ESLint and Prettier on touched files
- git diff --check

## Design verification

- checked implementation against desktop Figma node 39801:140506 and mobile node 40349:309314
- authenticated desktop/mobile runtime comparison remains pending because the fresh local browser stayed on the authentication redirect
- no VRT baseline is required for this dialog

## Dependency

This is stacked on #2381 so its clipboard control remains part of the resulting dialog. Retarget this PR to dev after #2381 merges.

Closes #2105