### PR TITLE
feat(profile): add "Filter posts" to the profile Posts tab

### DIFF
--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx
@@ -31,6 +31,29 @@ describe('FilterPostsBar', () => {
     fireEvent.change(input, { target: { value: 'bitcoin wallet' } });
     expect(onValueChange).toHaveBeenCalledWith('bitcoin wallet');
   });
+
+  it('renders the validation message below the pill with alert semantics', () => {
+    render(
+      <FilterPostsBar
+        value="one two three four five"
+        onValueChange={vi.fn()}
+        validationMessage="Search can contain up to 4 terms"
+      />,
+    );
+
+    const message = screen.getByRole('alert');
+    expect(message).toHaveTextContent('Search can contain up to 4 terms');
+    const input = screen.getByRole('textbox', { name: 'Filter posts' });
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', message.id);
+  });
+
+  it('omits the message and invalid state when the query is fine', () => {
+    render(<FilterPostsBar value="bitcoin" onValueChange={vi.fn()} />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Filter posts' })).toHaveAttribute('aria-invalid', 'false');
+  });
 });
 
 describe('FilterPostsBar - Snapshots', () => {

--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CONTENT_SEARCH_QUERY_MAX_LENGTH } from '@/config/search';
+import { FilterPostsBar } from './FilterPostsBar';
+
+describe('FilterPostsBar', () => {
+  it('renders the pill container with the input and search icon', () => {
+    const { container } = render(<FilterPostsBar value="" onValueChange={vi.fn()} />);
+
+    expect(screen.getByTestId('filter-posts-bar')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Filter posts' })).toHaveAttribute('placeholder', 'Filter posts');
+    expect(container.querySelector('svg.lucide-search')).toBeInTheDocument();
+  });
+
+  it('caps the input at the content-search max query length', () => {
+    render(<FilterPostsBar value="" onValueChange={vi.fn()} />);
+
+    expect(screen.getByRole('textbox', { name: 'Filter posts' })).toHaveAttribute(
+      'maxLength',
+      String(CONTENT_SEARCH_QUERY_MAX_LENGTH),
+    );
+  });
+
+  it('displays the controlled value and reports changes as plain strings', () => {
+    const onValueChange = vi.fn();
+    render(<FilterPostsBar value="bitcoin" onValueChange={onValueChange} />);
+
+    const input = screen.getByRole('textbox', { name: 'Filter posts' });
+    expect(input).toHaveValue('bitcoin');
+
+    fireEvent.change(input, { target: { value: 'bitcoin wallet' } });
+    expect(onValueChange).toHaveBeenCalledWith('bitcoin wallet');
+  });
+
+  it('matches snapshot', () => {
+    const { container } = render(<FilterPostsBar value="" onValueChange={vi.fn()} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx
@@ -31,7 +31,9 @@ describe('FilterPostsBar', () => {
     fireEvent.change(input, { target: { value: 'bitcoin wallet' } });
     expect(onValueChange).toHaveBeenCalledWith('bitcoin wallet');
   });
+});
 
+describe('FilterPostsBar - Snapshots', () => {
   it('matches snapshot', () => {
     const { container } = render(<FilterPostsBar value="" onValueChange={vi.fn()} />);
     expect(container.firstChild).toMatchSnapshot();

--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx.snap
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`FilterPostsBar - Snapshots > matches snapshot 1`] = `
   />
   <span
     aria-hidden="true"
-    class="pointer-events-none flex size-8 shrink-0 items-center justify-center"
+    class="pointer-events-none -mr-2 flex size-8 shrink-0 items-center justify-center"
   >
     <svg
       aria-hidden="true"

--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx.snap
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx.snap
@@ -1,0 +1,48 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`FilterPostsBar > matches snapshot 1`] = `
+<div
+  class="flex h-12 min-w-0 shrink-0 items-center gap-3 rounded-full border border-border px-6 py-3"
+  data-cy="profile-filter-posts"
+  data-testid="filter-posts-bar"
+  style="background: linear-gradient(180deg, rgb(7, 4, 10) 0%, rgb(27, 24, 32) 100%); backdrop-filter: blur(20px);"
+>
+  <input
+    aria-label="Filter posts"
+    class="flex w-full rounded-md border border-input px-3 py-1 shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-input disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 hover:ring-0 hover:outline-none focus:ring-0 focus:ring-offset-0 focus:outline-none aria-invalid:border-destructive aria-invalid:ring-destructive/40 h-auto min-w-20 flex-1 border-none bg-transparent pr-0 pl-0 text-base font-medium text-foreground md:text-base"
+    data-cy="profile-filter-posts-input"
+    data-testid="input"
+    maxlength="30"
+    placeholder="Filter posts"
+    type="text"
+    value=""
+  />
+  <span
+    aria-hidden="true"
+    class="pointer-events-none flex size-8 shrink-0 items-center justify-center"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-search size-4 text-muted-foreground"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m21 21-4.34-4.34"
+      />
+      <circle
+        cx="11"
+        cy="11"
+        r="8"
+      />
+    </svg>
+  </span>
+</div>
+`;

--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx.snap
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx.snap
@@ -2,47 +2,53 @@
 
 exports[`FilterPostsBar - Snapshots > matches snapshot 1`] = `
 <div
-  class="flex h-12 min-w-0 shrink-0 items-center gap-3 rounded-full border border-border px-6 py-3"
-  data-cy="profile-filter-posts"
-  data-testid="filter-posts-bar"
-  style="background: linear-gradient(180deg, rgb(7, 4, 10) 0%, rgb(27, 24, 32) 100%); backdrop-filter: blur(20px);"
+  class="flex min-w-0 shrink-0 flex-col gap-2"
+  data-testid="container"
 >
-  <input
-    aria-label="Filter posts"
-    class="flex w-full rounded-md border border-input px-3 py-1 shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-input disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 hover:ring-0 hover:outline-none focus:ring-0 focus:ring-offset-0 focus:outline-none aria-invalid:border-destructive aria-invalid:ring-destructive/40 h-auto min-w-20 flex-1 border-none bg-transparent pr-0 pl-0 text-base font-medium text-foreground md:text-base"
-    data-cy="profile-filter-posts-input"
-    data-testid="input"
-    maxlength="30"
-    placeholder="Filter posts"
-    type="text"
-    value=""
-  />
-  <span
-    aria-hidden="true"
-    class="pointer-events-none -mr-2 flex size-8 shrink-0 items-center justify-center"
+  <div
+    class="flex h-12 min-w-0 shrink-0 items-center gap-3 rounded-full border border-border px-6 py-3"
+    data-cy="profile-filter-posts"
+    data-testid="filter-posts-bar"
+    style="background: linear-gradient(180deg, rgb(7, 4, 10) 0%, rgb(27, 24, 32) 100%); backdrop-filter: blur(20px);"
   >
-    <svg
+    <input
+      aria-invalid="false"
+      aria-label="Filter posts"
+      class="flex w-full rounded-md border border-input px-3 py-1 shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-input disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 hover:ring-0 hover:outline-none focus:ring-0 focus:ring-offset-0 focus:outline-none aria-invalid:border-destructive aria-invalid:ring-destructive/40 h-auto min-w-20 flex-1 border-none bg-transparent pr-0 pl-0 text-base font-medium text-foreground md:text-base"
+      data-cy="profile-filter-posts-input"
+      data-testid="input"
+      maxlength="30"
+      placeholder="Filter posts"
+      type="text"
+      value=""
+    />
+    <span
       aria-hidden="true"
-      class="lucide lucide-search size-4 text-muted-foreground"
-      fill="none"
-      height="24"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
+      class="pointer-events-none -mr-2 flex size-8 shrink-0 items-center justify-center"
     >
-      <path
-        d="m21 21-4.34-4.34"
-      />
-      <circle
-        cx="11"
-        cy="11"
-        r="8"
-      />
-    </svg>
-  </span>
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-search size-4 text-muted-foreground"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="m21 21-4.34-4.34"
+        />
+        <circle
+          cx="11"
+          cy="11"
+          r="8"
+        />
+      </svg>
+    </span>
+  </div>
 </div>
 `;

--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx.snap
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`FilterPostsBar > matches snapshot 1`] = `
+exports[`FilterPostsBar - Snapshots > matches snapshot 1`] = `
 <div
   class="flex h-12 min-w-0 shrink-0 items-center gap-3 rounded-full border border-border px-6 py-3"
   data-cy="profile-filter-posts"

--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.tsx
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.tsx
@@ -3,38 +3,51 @@
 import { Search } from 'lucide-react';
 import { Container } from '@/atoms/Container/Container';
 import { Input } from '@/atoms/Input/Input';
+import { Typography } from '@/atoms/Typography/Typography';
 import { CONTENT_SEARCH_QUERY_MAX_LENGTH, SEARCH_CLOSED_STYLE } from '@/config/search';
 import type { FilterPostsBarProps } from './FilterPostsBar.types';
+
+const MESSAGE_ID = 'filter-posts-bar-message';
 
 /**
  * FilterPostsBar
  *
  * Pill-shaped inline search input for the profile Posts tab ("Filter posts",
  * issue #2234). Presentation-only: debounce/validation live in
- * `useProfilePostsFilter`. Modeled on `SearchInputBar` minus tags/dropdown.
+ * `useProfilePostsFilter`. Modeled on `SearchInputBar` minus tags/dropdown;
+ * the validation message mirrors the `InputField` message pattern.
  */
-export function FilterPostsBar({ value, onValueChange }: FilterPostsBarProps) {
+export function FilterPostsBar({ value, onValueChange, validationMessage }: FilterPostsBarProps) {
   return (
-    <Container
-      data-testid="filter-posts-bar"
-      data-cy="profile-filter-posts"
-      className="flex h-12 min-w-0 shrink-0 items-center gap-3 rounded-full border border-border px-6 py-3"
-      style={SEARCH_CLOSED_STYLE}
-      overrideDefaults
-    >
-      <Input
-        type="text"
-        placeholder={'Filter posts'}
-        value={value}
-        onChange={(event) => onValueChange(event.target.value)}
-        maxLength={CONTENT_SEARCH_QUERY_MAX_LENGTH}
-        data-cy="profile-filter-posts-input"
-        aria-label={'Filter posts'}
-        className="h-auto min-w-20 flex-1 border-none bg-transparent pr-0 pl-0 text-base font-medium text-foreground md:text-base"
-      />
-      <span className="pointer-events-none -mr-2 flex size-8 shrink-0 items-center justify-center" aria-hidden="true">
-        <Search className="size-4 text-muted-foreground" />
-      </span>
+    <Container overrideDefaults className="flex min-w-0 shrink-0 flex-col gap-2">
+      <Container
+        data-testid="filter-posts-bar"
+        data-cy="profile-filter-posts"
+        className="flex h-12 min-w-0 shrink-0 items-center gap-3 rounded-full border border-border px-6 py-3"
+        style={SEARCH_CLOSED_STYLE}
+        overrideDefaults
+      >
+        <Input
+          type="text"
+          placeholder={'Filter posts'}
+          value={value}
+          onChange={(event) => onValueChange(event.target.value)}
+          maxLength={CONTENT_SEARCH_QUERY_MAX_LENGTH}
+          data-cy="profile-filter-posts-input"
+          aria-label={'Filter posts'}
+          aria-invalid={!!validationMessage}
+          aria-describedby={validationMessage ? MESSAGE_ID : undefined}
+          className="h-auto min-w-20 flex-1 border-none bg-transparent pr-0 pl-0 text-base font-medium text-foreground md:text-base"
+        />
+        <span className="pointer-events-none -mr-2 flex size-8 shrink-0 items-center justify-center" aria-hidden="true">
+          <Search className="size-4 text-muted-foreground" />
+        </span>
+      </Container>
+      {validationMessage && (
+        <Typography as="small" size="sm" id={MESSAGE_ID} role="alert" className="ml-6 text-red-500">
+          {validationMessage}
+        </Typography>
+      )}
     </Container>
   );
 }

--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.tsx
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.tsx
@@ -32,7 +32,7 @@ export function FilterPostsBar({ value, onValueChange }: FilterPostsBarProps) {
         aria-label={'Filter posts'}
         className="h-auto min-w-20 flex-1 border-none bg-transparent pr-0 pl-0 text-base font-medium text-foreground md:text-base"
       />
-      <span className="pointer-events-none flex size-8 shrink-0 items-center justify-center" aria-hidden="true">
+      <span className="pointer-events-none -mr-2 flex size-8 shrink-0 items-center justify-center" aria-hidden="true">
         <Search className="size-4 text-muted-foreground" />
       </span>
     </Container>

--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.tsx
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Search } from 'lucide-react';
+import { Container } from '@/atoms/Container/Container';
+import { Input } from '@/atoms/Input/Input';
+import { CONTENT_SEARCH_QUERY_MAX_LENGTH, SEARCH_CLOSED_STYLE } from '@/config/search';
+import type { FilterPostsBarProps } from './FilterPostsBar.types';
+
+/**
+ * FilterPostsBar
+ *
+ * Pill-shaped inline search input for the profile Posts tab ("Filter posts",
+ * issue #2234). Presentation-only: debounce/validation live in
+ * `useProfilePostsFilter`. Modeled on `SearchInputBar` minus tags/dropdown.
+ */
+export function FilterPostsBar({ value, onValueChange }: FilterPostsBarProps) {
+  return (
+    <Container
+      data-testid="filter-posts-bar"
+      data-cy="profile-filter-posts"
+      className="flex h-12 min-w-0 shrink-0 items-center gap-3 rounded-full border border-border px-6 py-3"
+      style={SEARCH_CLOSED_STYLE}
+      overrideDefaults
+    >
+      <Input
+        type="text"
+        placeholder={'Filter posts'}
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+        maxLength={CONTENT_SEARCH_QUERY_MAX_LENGTH}
+        data-cy="profile-filter-posts-input"
+        aria-label={'Filter posts'}
+        className="h-auto min-w-20 flex-1 border-none bg-transparent pr-0 pl-0 text-base font-medium text-foreground md:text-base"
+      />
+      <span className="pointer-events-none flex size-8 shrink-0 items-center justify-center" aria-hidden="true">
+        <Search className="size-4 text-muted-foreground" />
+      </span>
+    </Container>
+  );
+}

--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.types.ts
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.types.ts
@@ -1,0 +1,6 @@
+export interface FilterPostsBarProps {
+  /** Raw input value (controlled). */
+  value: string;
+  /** Called with the raw input string on every change. */
+  onValueChange: (value: string) => void;
+}

--- a/src/components/molecules/FilterPostsBar/FilterPostsBar.types.ts
+++ b/src/components/molecules/FilterPostsBar/FilterPostsBar.types.ts
@@ -3,4 +3,6 @@ export interface FilterPostsBarProps {
   value: string;
   /** Called with the raw input string on every change. */
   onValueChange: (value: string) => void;
+  /** Validator message for a settled-but-invalid query; rendered below the pill. */
+  validationMessage?: string | null;
 }

--- a/src/components/molecules/FilterPostsEmpty/FilterPostsEmpty.test.tsx
+++ b/src/components/molecules/FilterPostsEmpty/FilterPostsEmpty.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FilterPostsEmpty } from './FilterPostsEmpty';
+
+vi.mock('@/molecules/IllustratedEmptyState/IllustratedEmptyState', () => ({
+  IllustratedEmptyState: ({
+    imageSrc,
+    icon: Icon,
+    title,
+    subtitle,
+  }: {
+    imageSrc: string;
+    imageAlt: string;
+    icon: React.ComponentType;
+    title: string;
+    subtitle: React.ReactNode;
+  }) => (
+    <div data-testid="empty-state" data-src={imageSrc}>
+      <Icon />
+      <h3>{title}</h3>
+      <p>{subtitle}</p>
+    </div>
+  ),
+}));
+
+describe('FilterPostsEmpty', () => {
+  it('renders the no-results title and hint', () => {
+    render(<FilterPostsEmpty />);
+
+    expect(screen.getByText('No posts match your search')).toBeInTheDocument();
+    expect(screen.getByText('Try a different search term.')).toBeInTheDocument();
+  });
+
+  it('matches snapshot', () => {
+    const { container } = render(<FilterPostsEmpty />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/FilterPostsEmpty/FilterPostsEmpty.test.tsx
+++ b/src/components/molecules/FilterPostsEmpty/FilterPostsEmpty.test.tsx
@@ -30,7 +30,9 @@ describe('FilterPostsEmpty', () => {
     expect(screen.getByText('No posts match your search')).toBeInTheDocument();
     expect(screen.getByText('Try a different search term.')).toBeInTheDocument();
   });
+});
 
+describe('FilterPostsEmpty - Snapshots', () => {
   it('matches snapshot', () => {
     const { container } = render(<FilterPostsEmpty />);
     expect(container.firstChild).toMatchSnapshot();

--- a/src/components/molecules/FilterPostsEmpty/FilterPostsEmpty.test.tsx.snap
+++ b/src/components/molecules/FilterPostsEmpty/FilterPostsEmpty.test.tsx.snap
@@ -1,0 +1,37 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`FilterPostsEmpty > matches snapshot 1`] = `
+<div
+  data-src="/images/tagged-empty-state.webp"
+  data-testid="empty-state"
+>
+  <svg
+    aria-hidden="true"
+    class="lucide lucide-search"
+    fill="none"
+    height="24"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="m21 21-4.34-4.34"
+    />
+    <circle
+      cx="11"
+      cy="11"
+      r="8"
+    />
+  </svg>
+  <h3>
+    No posts match your search
+  </h3>
+  <p>
+    Try a different search term.
+  </p>
+</div>
+`;

--- a/src/components/molecules/FilterPostsEmpty/FilterPostsEmpty.test.tsx.snap
+++ b/src/components/molecules/FilterPostsEmpty/FilterPostsEmpty.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`FilterPostsEmpty > matches snapshot 1`] = `
+exports[`FilterPostsEmpty - Snapshots > matches snapshot 1`] = `
 <div
   data-src="/images/tagged-empty-state.webp"
   data-testid="empty-state"

--- a/src/components/molecules/FilterPostsEmpty/FilterPostsEmpty.tsx
+++ b/src/components/molecules/FilterPostsEmpty/FilterPostsEmpty.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Search } from 'lucide-react';
+import { IllustratedEmptyState } from '../IllustratedEmptyState/IllustratedEmptyState';
+
+/**
+ * FilterPostsEmpty
+ *
+ * Shown on the profile Posts tab when an active "Filter posts" query matches
+ * nothing. Copy and artwork are placeholders pending design confirmation —
+ * issue #2234 and its Figma frame document no no-results state.
+ */
+export function FilterPostsEmpty() {
+  return (
+    <IllustratedEmptyState
+      imageSrc="/images/tagged-empty-state.webp"
+      imageAlt={'Filter posts - Empty state'}
+      icon={Search}
+      title={'No posts match your search'}
+      subtitle={'Try a different search term.'}
+    />
+  );
+}

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { PubkyAppFeedLayout, PubkyAppFeedReach, PubkyAppFeedSort } from 'pubky-app-specs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TIMELINE_FEED_VARIANT } from '@/config/feed';
@@ -6,12 +6,14 @@ import { NEXUS_STREAM_MAX_LIMIT } from '@/config/nexus';
 import { useCustomFeed } from '@/hooks/useCustomFeed/useCustomFeed';
 import { useCustomStreamId } from '@/hooks/useCustomStreamId/useCustomStreamId';
 import { useFeedLayoutResolution } from '@/hooks/useFeedLayoutResolution/useFeedLayoutResolution';
+import { PROFILE_POSTS_FILTER_DEBOUNCE_MS } from '@/hooks/useProfilePostsFilter/useProfilePostsFilter.constants';
 import type { UsePullToRefreshResult } from '@/hooks/usePullToRefresh/usePullToRefresh.types';
 import { useStreamIdFromFilters } from '@/hooks/useStreamIdFromFilters/useStreamIdFromFilters';
 import { useStreamPagination } from '@/hooks/useStreamPagination/useStreamPagination';
 import {
   buildAuthorCollectionsStreamId,
   buildCollectionItemsStreamId,
+  buildContentSearchStreamId,
   type PostStreamId,
   PostStreamTypes,
 } from '@/models/stream/post/postStream.types';
@@ -146,6 +148,16 @@ vi.mock('@/molecules/Timeline/TimelineLoading', () => {
   };
 });
 
+// Both profile empty states pull in heavy trees (dialogs, auth); stubs keep the
+// Profile variant's conditional empty-state assertions focused on the switch.
+vi.mock('@/molecules/PostsEmpty/PostsEmpty', () => ({
+  PostsEmpty: () => <div data-testid="posts-empty" />,
+}));
+
+vi.mock('@/molecules/FilterPostsEmpty/FilterPostsEmpty', () => ({
+  FilterPostsEmpty: () => <div data-testid="filter-posts-empty" />,
+}));
+
 vi.mock('@/organisms/Timeline/Posts/Posts', () => {
   return {
     TimelinePosts: ({
@@ -154,12 +166,14 @@ vi.mock('@/organisms/Timeline/Posts/Posts', () => {
       loadingMore,
       error,
       hasMore,
+      emptyState,
     }: {
       postIds: string[];
       loading: boolean;
       loadingMore: boolean;
       error: string | null;
       hasMore: boolean;
+      emptyState?: React.ReactNode;
     }) => (
       <div data-feed-renderer="columns" data-testid="timeline-posts" data-post-ids={postIds.join(',')}>
         <span data-testid="post-count">{postIds.length}</span>
@@ -167,6 +181,7 @@ vi.mock('@/organisms/Timeline/Posts/Posts', () => {
         <span data-testid="loading-more">{loadingMore.toString()}</span>
         <span data-testid="error">{error || 'none'}</span>
         <span data-testid="has-more">{hasMore.toString()}</span>
+        {postIds.length === 0 && !loading && !hasMore ? emptyState : null}
       </div>
     ),
   };
@@ -647,6 +662,23 @@ describe('TimelineFeed', () => {
   });
 
   describe('Profile Variant', () => {
+    const profilePubky = 'profile-user-pubky';
+
+    const renderProfileFeed = () =>
+      render(
+        <ProfileProvider pubky={profilePubky}>
+          <TimelineFeed variant={TIMELINE_FEED_VARIANT.PROFILE} />
+        </ProfileProvider>,
+      );
+
+    /** Types into the filter bar and settles its debounce (requires fake timers). */
+    const applyFilterQuery = (value: string) => {
+      fireEvent.change(screen.getByRole('textbox', { name: 'Filter posts' }), { target: { value } });
+      act(() => {
+        vi.advanceTimersByTime(PROFILE_POSTS_FILTER_DEBOUNCE_MS);
+      });
+    };
+
     it('should show loading when profile context has no pubky', () => {
       render(
         <ProfileProvider>
@@ -658,6 +690,69 @@ describe('TimelineFeed', () => {
       // TimelineFeed shows loading state and doesn't call useStreamPagination
       expect(screen.getByTestId('timeline-loading')).toBeInTheDocument();
       expect(mockUseStreamPagination).not.toHaveBeenCalled();
+    });
+
+    it('paginates the author stream and renders the filter bar when idle', () => {
+      renderProfileFeed();
+
+      expect(mockUseStreamPagination).toHaveBeenCalledWith({ streamId: `author:${profilePubky}` });
+      expect(screen.getByTestId('filter-posts-bar')).toBeInTheDocument();
+    });
+
+    describe('with a settled filter query', () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('swaps to the author-scoped content-search stream once a valid query settles', () => {
+        renderProfileFeed();
+
+        applyFilterQuery('bitcoin');
+
+        expect(mockUseStreamPagination).toHaveBeenLastCalledWith({
+          streamId: buildContentSearchStreamId('bitcoin', 'all', profilePubky),
+        });
+        // The bar survives the stream swap (focus preservation contract).
+        expect(screen.getByRole('textbox', { name: 'Filter posts' })).toHaveValue('bitcoin');
+      });
+
+      it('returns to the author stream immediately when the input is cleared', () => {
+        renderProfileFeed();
+
+        applyFilterQuery('bitcoin');
+        fireEvent.change(screen.getByRole('textbox', { name: 'Filter posts' }), { target: { value: '' } });
+
+        // No debounce advance: the clear applies synchronously.
+        expect(mockUseStreamPagination).toHaveBeenLastCalledWith({ streamId: `author:${profilePubky}` });
+      });
+
+      it('keeps the author stream for a query below the minimum length', () => {
+        renderProfileFeed();
+
+        applyFilterQuery('a');
+
+        expect(mockUseStreamPagination).toHaveBeenLastCalledWith({ streamId: `author:${profilePubky}` });
+      });
+
+      it('shows the search no-results state while filtering and the regular one when idle', () => {
+        mockUseStreamPagination.mockReturnValue({
+          ...defaultPaginationResult,
+          postIds: [],
+          hasMore: false,
+        });
+
+        renderProfileFeed();
+        expect(screen.getByTestId('posts-empty')).toBeInTheDocument();
+        expect(screen.queryByTestId('filter-posts-empty')).not.toBeInTheDocument();
+
+        applyFilterQuery('bitcoin');
+        expect(screen.getByTestId('filter-posts-empty')).toBeInTheDocument();
+        expect(screen.queryByTestId('posts-empty')).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
@@ -6,6 +6,7 @@ import { useCustomStreamId } from '@/hooks/useCustomStreamId/useCustomStreamId';
 import { useFeedLayoutResolution } from '@/hooks/useFeedLayoutResolution/useFeedLayoutResolution';
 import { useHotStreamId } from '@/hooks/useHotStreamId/useHotStreamId';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
+import { useProfilePostsFilter } from '@/hooks/useProfilePostsFilter/useProfilePostsFilter';
 import { useSearchStreamId } from '@/hooks/useSearchStreamId/useSearchStreamId';
 import { useStreamIdFromFilters } from '@/hooks/useStreamIdFromFilters/useStreamIdFromFilters';
 import { useSyncInteractiveVisualContent } from '@/hooks/useSyncInteractiveVisualContent/useSyncInteractiveVisualContent';
@@ -16,8 +17,11 @@ import {
   type AuthorStreamCompositeId,
   buildAuthorCollectionsStreamId,
   buildCollectionItemsStreamId,
+  buildContentSearchStreamId,
   PostStreamTypes,
 } from '@/models/stream/post/postStream.types';
+import { FilterPostsBar } from '@/molecules/FilterPostsBar/FilterPostsBar';
+import { FilterPostsEmpty } from '@/molecules/FilterPostsEmpty/FilterPostsEmpty';
 import { PostsEmpty } from '@/molecules/PostsEmpty/PostsEmpty';
 import { TimelineLoading } from '@/molecules/Timeline/TimelineLoading';
 import { getTagsLayoutForSurfaceLayout } from '@/organisms/PostMain/PostMainLayoutRules';
@@ -156,7 +160,15 @@ function BookmarksTimelineFeed({
 
 function ProfileTimelineFeed({ children }: { children?: TimelineFeedProps['children'] }) {
   const { pubky } = useProfileContext();
-  const streamId = pubky ? (`${StreamSource.AUTHOR}:${pubky}` as AuthorStreamCompositeId) : undefined;
+  const { inputValue, onInputChange, activeQuery } = useProfilePostsFilter();
+  // An active query swaps the stream to the author-scoped content search;
+  // the bar stays mounted across the swap (it renders as feed children), so
+  // input focus survives the results changing underneath it.
+  const streamId = !pubky
+    ? undefined
+    : activeQuery
+      ? buildContentSearchStreamId(activeQuery, 'all', pubky)
+      : (`${StreamSource.AUTHOR}:${pubky}` as AuthorStreamCompositeId);
   const layoutResolution = useFeedLayoutResolution(TIMELINE_FEED_VARIANT.PROFILE);
   const tagsLayout = getTagsLayoutForSurfaceLayout(layoutResolution.effectiveLayout);
 
@@ -166,8 +178,9 @@ function ProfileTimelineFeed({ children }: { children?: TimelineFeedProps['child
       variant={TIMELINE_FEED_VARIANT.PROFILE}
       tagsLayout={tagsLayout}
       layoutResolution={layoutResolution}
-      emptyState={<PostsEmpty />}
+      emptyState={activeQuery ? <FilterPostsEmpty /> : <PostsEmpty />}
     >
+      <FilterPostsBar value={inputValue} onValueChange={onInputChange} />
       {children}
     </TimelineFeedWithStream>
   );

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
@@ -160,7 +160,7 @@ function BookmarksTimelineFeed({
 
 function ProfileTimelineFeed({ children }: { children?: TimelineFeedProps['children'] }) {
   const { pubky } = useProfileContext();
-  const { inputValue, onInputChange, activeQuery } = useProfilePostsFilter();
+  const { inputValue, onInputChange, activeQuery, validationMessage } = useProfilePostsFilter();
   // An active query swaps the stream to the author-scoped content search;
   // the bar stays mounted across the swap (it renders as feed children), so
   // input focus survives the results changing underneath it.
@@ -180,7 +180,7 @@ function ProfileTimelineFeed({ children }: { children?: TimelineFeedProps['child
       layoutResolution={layoutResolution}
       emptyState={activeQuery ? <FilterPostsEmpty /> : <PostsEmpty />}
     >
-      <FilterPostsBar value={inputValue} onValueChange={onInputChange} />
+      <FilterPostsBar value={inputValue} onValueChange={onInputChange} validationMessage={validationMessage} />
       {children}
     </TimelineFeedWithStream>
   );

--- a/src/config/search.ts
+++ b/src/config/search.ts
@@ -40,6 +40,13 @@ export const SEARCH_CONTENT_TAGS_PER_TERM_LIMIT = 3;
 export const SEARCH_CONTENT_TAGS_MAX_TOTAL = 8;
 
 /**
+ * Nexus by_content pagination bound (`BoundedSkip<1000>` in pubky-nexus): a `skip` up to and
+ * INCLUDING this value is a valid request; anything above is rejected with a validation error.
+ * Content-search streams stop paginating once the next offset would exceed it.
+ */
+export const CONTENT_SEARCH_MAX_SKIP = 1000;
+
+/**
  * Search bar closed state style (pill shape)
  * - Gradient background matching Figma design
  * - Backdrop blur for glass effect

--- a/src/core/application/notification/notification.test.ts
+++ b/src/core/application/notification/notification.test.ts
@@ -71,7 +71,7 @@ const mockFetchMissingEntities = () => {
   });
   vi.spyOn(LocalStreamPostsService, 'getNotPersistedPostsInCache').mockResolvedValue([]);
   vi.spyOn(LocalStreamUsersService, 'getNotPersistedUsersInCache').mockResolvedValue([]);
-  vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(undefined);
+  vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(true);
   vi.spyOn(UserStreamApplication, 'fetchMissingUsersFromNexus').mockResolvedValue(undefined);
 };
 
@@ -600,7 +600,7 @@ describe('NotificationApplication.fetchMissingEntities', () => {
     });
     vi.spyOn(LocalStreamPostsService, 'getNotPersistedPostsInCache').mockResolvedValue([]);
     vi.spyOn(LocalStreamUsersService, 'getNotPersistedUsersInCache').mockResolvedValue([relatedUserId]);
-    vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(undefined);
+    vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(true);
     const fetchUsersSpy = vi.spyOn(UserStreamApplication, 'fetchMissingUsersFromNexus').mockResolvedValue(undefined);
 
     await NotificationApplication.fetchMissingEntities({ notifications, viewerId });
@@ -622,7 +622,7 @@ describe('NotificationApplication.fetchMissingEntities', () => {
     });
     vi.spyOn(LocalStreamPostsService, 'getNotPersistedPostsInCache').mockResolvedValue([relatedPostId]);
     vi.spyOn(LocalStreamUsersService, 'getNotPersistedUsersInCache').mockResolvedValue([]);
-    const fetchPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(undefined);
+    const fetchPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(true);
     vi.spyOn(UserStreamApplication, 'fetchMissingUsersFromNexus').mockResolvedValue(undefined);
 
     await NotificationApplication.fetchMissingEntities({ notifications, viewerId });
@@ -644,7 +644,7 @@ describe('NotificationApplication.fetchMissingEntities', () => {
     // All entities are already cached
     vi.spyOn(LocalStreamPostsService, 'getNotPersistedPostsInCache').mockResolvedValue([]);
     vi.spyOn(LocalStreamUsersService, 'getNotPersistedUsersInCache').mockResolvedValue([]);
-    const fetchPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(undefined);
+    const fetchPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(true);
     const fetchUsersSpy = vi.spyOn(UserStreamApplication, 'fetchMissingUsersFromNexus').mockResolvedValue(undefined);
 
     await NotificationApplication.fetchMissingEntities({ notifications, viewerId });
@@ -674,7 +674,7 @@ describe('NotificationApplication.fetchMissingEntities', () => {
     // The edited post is already cached — nothing is "missing".
     vi.spyOn(LocalStreamPostsService, 'getNotPersistedPostsInCache').mockResolvedValue([]);
     vi.spyOn(LocalStreamUsersService, 'getNotPersistedUsersInCache').mockResolvedValue([]);
-    const fetchPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(undefined);
+    const fetchPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(true);
     vi.spyOn(UserStreamApplication, 'fetchMissingUsersFromNexus').mockResolvedValue(undefined);
 
     await NotificationApplication.fetchMissingEntities({ notifications, viewerId });

--- a/src/core/application/post/post.test.ts
+++ b/src/core/application/post/post.test.ts
@@ -1014,9 +1014,7 @@ describe('Post Application', () => {
     it('should fetch post from Nexus using stream posts logic', async () => {
       const mockViewerId = 'test-viewer-id' as Pubky;
       const readSpyFirst = vi.spyOn(LocalPostService, 'readDetails').mockResolvedValueOnce(null);
-      const fetchMissingSpy = vi
-        .spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus')
-        .mockResolvedValue(undefined);
+      const fetchMissingSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(true);
       const readSpySecond = vi.spyOn(LocalPostService, 'readDetails').mockResolvedValueOnce(mockPostDetails);
 
       const result = await PostApplication.getOrFetch({
@@ -1036,9 +1034,7 @@ describe('Post Application', () => {
     it('should return null when post not found in Nexus', async () => {
       const mockViewerId = 'test-viewer-id' as Pubky;
       const readSpyFirst = vi.spyOn(LocalPostService, 'readDetails').mockResolvedValueOnce(null);
-      const fetchMissingSpy = vi
-        .spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus')
-        .mockResolvedValue(undefined);
+      const fetchMissingSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(true);
       const readSpySecond = vi.spyOn(LocalPostService, 'readDetails').mockResolvedValueOnce(null);
 
       const result = await PostApplication.getOrFetch({
@@ -1068,9 +1064,7 @@ describe('Post Application', () => {
 
     it('should fetch post from Nexus and return persisted data', async () => {
       const mockViewerId = 'test-viewer-id' as Pubky;
-      const fetchMissingSpy = vi
-        .spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus')
-        .mockResolvedValue(undefined);
+      const fetchMissingSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(true);
       const readSpy = vi.spyOn(LocalPostService, 'readDetails').mockResolvedValueOnce(mockPostDetails);
 
       const result = await PostApplication.fetch({
@@ -1089,9 +1083,7 @@ describe('Post Application', () => {
 
     it('should return null when post not found on Nexus', async () => {
       const mockViewerId = 'test-viewer-id' as Pubky;
-      const fetchMissingSpy = vi
-        .spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus')
-        .mockResolvedValue(undefined);
+      const fetchMissingSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(true);
       const readSpy = vi.spyOn(LocalPostService, 'readDetails').mockResolvedValueOnce(null);
 
       const result = await PostApplication.fetch({

--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -425,6 +425,87 @@ describe('PostStreamApplication', () => {
 
       expect(result).toEqual([livePostId, deletedPostId]);
     });
+
+    describe('author-scoped content search (profile "Filter posts")', () => {
+      const scopedStreamId = buildContentSearchStreamId('bitcoin', 'all', DEFAULT_AUTHOR as Pubky);
+
+      const createPostRelationships = async (postId: string, replied: string | null = null) => {
+        await PostRelationshipsModel.create({ id: postId, replied, reposted: null, mentioned: [] });
+      };
+
+      it('excludes collection-kind posts (profile Posts tab contract)', async () => {
+        const shortPostId = `${DEFAULT_AUTHOR}:short-post`;
+        const collectionPostId = `${DEFAULT_AUTHOR}:collection-post`;
+        await createPostDetailWithKind(shortPostId, 'short');
+        await createPostDetailWithKind(collectionPostId, 'collection');
+        await createPostRelationships(shortPostId);
+        await createPostRelationships(collectionPostId);
+
+        const result = await PostStreamApplication.filterStreamPosts({
+          streamId: scopedStreamId,
+          postIds: [shortPostId, collectionPostId],
+        });
+
+        expect(result).toEqual([shortPostId]);
+      });
+
+      it('drops replies classified via the local relationships row', async () => {
+        const rootPostId = `${DEFAULT_AUTHOR}:root-post`;
+        const replyPostId = `${DEFAULT_AUTHOR}:reply-post`;
+        await createPostDetailWithKind(rootPostId, 'short');
+        await createPostDetailWithKind(replyPostId, 'short');
+        await createPostRelationships(rootPostId, null);
+        await createPostRelationships(replyPostId, `pubky://${DEFAULT_AUTHOR}/pub/pubky.app/posts/parent-post`);
+
+        const result = await PostStreamApplication.filterStreamPosts({
+          streamId: scopedStreamId,
+          postIds: [rootPostId, replyPostId],
+        });
+
+        expect(result).toEqual([rootPostId]);
+      });
+
+      it('keeps unclassifiable posts pre-hydration (fail-open first pass)', async () => {
+        const unclassifiedPostId = `${DEFAULT_AUTHOR}:no-relationships-post`;
+        await createPostDetailWithKind(unclassifiedPostId, 'short');
+
+        const result = await PostStreamApplication.filterStreamPosts({
+          streamId: scopedStreamId,
+          postIds: [unclassifiedPostId],
+        });
+
+        expect(result).toEqual([unclassifiedPostId]);
+      });
+
+      it('drops still-unclassifiable posts in the strict post-hydration pass', async () => {
+        const classifiedPostId = `${DEFAULT_AUTHOR}:classified-post`;
+        const unclassifiedPostId = `${DEFAULT_AUTHOR}:no-relationships-post`;
+        await createPostDetailWithKind(classifiedPostId, 'short');
+        await createPostDetailWithKind(unclassifiedPostId, 'short');
+        await createPostRelationships(classifiedPostId, null);
+
+        const result = await PostStreamApplication.filterStreamPosts({
+          streamId: scopedStreamId,
+          postIds: [classifiedPostId, unclassifiedPostId],
+          strictReplyClassification: true,
+        });
+
+        expect(result).toEqual([classifiedPostId]);
+      });
+
+      it('leaves the global (unscoped) content search untouched by the reply filter', async () => {
+        const replyPostId = `${DEFAULT_AUTHOR}:reply-post`;
+        await createPostDetailWithKind(replyPostId, 'short');
+        await createPostRelationships(replyPostId, `pubky://${DEFAULT_AUTHOR}/pub/pubky.app/posts/parent-post`);
+
+        const result = await PostStreamApplication.filterStreamPosts({
+          streamId: buildContentSearchStreamId('bitcoin'),
+          postIds: [replyPostId],
+        });
+
+        expect(result).toEqual([replyPostId]);
+      });
+    });
   });
 
   describe('getOrFetchStreamSlice', () => {
@@ -537,6 +618,36 @@ describe('PostStreamApplication', () => {
         expect(result.nextCursor).toBe(1000);
         expect(result.reachedEnd).toBe(false);
       });
+    });
+
+    it('flags details-cached posts without a relationships row as cache misses on author-scoped search', async () => {
+      // Reply exclusion classifies via relationships.replied; a post whose details are cached
+      // but whose relationships row is missing must still be hydrated, or it would stay
+      // fail-open (then be dropped by the strict second pass) forever.
+      const scopedStreamId = buildContentSearchStreamId('bitcoin', 'all', DEFAULT_AUTHOR as Pubky);
+      const classifiedPostId = `${DEFAULT_AUTHOR}:classified-post`;
+      const unclassifiedPostId = `${DEFAULT_AUTHOR}:needs-hydration-post`;
+      await createPostDetailWithKind(classifiedPostId, 'short');
+      await createPostDetailWithKind(unclassifiedPostId, 'short');
+      await PostRelationshipsModel.create({ id: classifiedPostId, replied: null, reposted: null, mentioned: [] });
+
+      vi.spyOn(NexusPostStreamService, 'fetch').mockResolvedValue({
+        post_keys: [classifiedPostId, unclassifiedPostId],
+        last_post_score: null,
+      });
+
+      const result = await PostStreamApplication.getOrFetchStreamSlice({
+        streamId: scopedStreamId,
+        limit: 2,
+        streamHead: 0,
+        streamTail: 0,
+        viewerId: null,
+      });
+
+      expect(result.cacheMissPostIds).toEqual([unclassifiedPostId]);
+      // Fail-open: the unclassified post stays visible until the controller's
+      // post-hydration second pass classifies (or strictly drops) it.
+      expect(result.nextPageIds).toEqual([classifiedPostId, unclassifiedPostId]);
     });
 
     it('should return posts from cache when available (no cursor)', async () => {

--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -459,6 +459,86 @@ describe('PostStreamApplication', () => {
       expect(persistStreamSpy).not.toHaveBeenCalled();
     });
 
+    describe('content-search skip bound (Nexus BoundedSkip, inclusive at 1000)', () => {
+      const contentStreamId = buildContentSearchStreamId('bitcoin');
+
+      it('still issues the request when the offset sits exactly on the bound', async () => {
+        const nexusFetchSpy = vi.spyOn(NexusPostStreamService, 'fetch').mockResolvedValue({
+          post_keys: [`${DEFAULT_AUTHOR}:post-a`, `${DEFAULT_AUTHOR}:post-b`],
+          last_post_score: null,
+        });
+
+        const result = await PostStreamApplication.getOrFetchStreamSlice({
+          streamId: contentStreamId,
+          limit: 2,
+          streamHead: 0,
+          streamTail: 1000, // skip = 1000 is the last valid offset
+          viewerId: null,
+        });
+
+        expect(nexusFetchSpy).toHaveBeenCalledTimes(1);
+        expect(nexusFetchSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ params: expect.objectContaining({ skip: 1000 }) }),
+        );
+        // The page is consumed; only the follow-up (skip 1002 > 1000) is suppressed.
+        expect(result.nextPageIds).toEqual([`${DEFAULT_AUTHOR}:post-a`, `${DEFAULT_AUTHOR}:post-b`]);
+        expect(result.reachedEnd).toBe(true);
+      });
+
+      it('reports the end without calling Nexus when the incoming offset is already past the bound', async () => {
+        const nexusFetchSpy = vi.spyOn(NexusPostStreamService, 'fetch');
+
+        const result = await PostStreamApplication.getOrFetchStreamSlice({
+          streamId: contentStreamId,
+          limit: 2,
+          streamHead: 0,
+          streamTail: 1001, // Nexus would reject this skip
+          viewerId: null,
+        });
+
+        expect(nexusFetchSpy).not.toHaveBeenCalled();
+        expect(result.nextPageIds).toEqual([]);
+        expect(result.reachedEnd).toBe(true);
+      });
+
+      it('marks a full page ended when the raw ids advance the offset past the bound', async () => {
+        vi.spyOn(NexusPostStreamService, 'fetch').mockResolvedValue({
+          post_keys: [`${DEFAULT_AUTHOR}:post-a`, `${DEFAULT_AUTHOR}:post-b`],
+          last_post_score: null,
+        });
+
+        const result = await PostStreamApplication.getOrFetchStreamSlice({
+          streamId: contentStreamId,
+          limit: 2,
+          streamHead: 0,
+          streamTail: 999, // valid request, but 999 + 2 = 1001 overflows the bound
+          viewerId: null,
+        });
+
+        expect(result.nextPageIds).toHaveLength(2);
+        expect(result.reachedEnd).toBe(true);
+      });
+
+      it('keeps paginating when the raw ids land the next offset exactly on the bound', async () => {
+        vi.spyOn(NexusPostStreamService, 'fetch').mockResolvedValue({
+          post_keys: [`${DEFAULT_AUTHOR}:post-a`, `${DEFAULT_AUTHOR}:post-b`],
+          last_post_score: null,
+        });
+
+        const result = await PostStreamApplication.getOrFetchStreamSlice({
+          streamId: contentStreamId,
+          limit: 2,
+          streamHead: 0,
+          streamTail: 998, // 998 + 2 = 1000: the next request is still valid
+          viewerId: null,
+        });
+
+        expect(result.nextPageIds).toHaveLength(2);
+        expect(result.nextCursor).toBe(1000);
+        expect(result.reachedEnd).toBe(false);
+      });
+    });
+
     it('should return posts from cache when available (no cursor)', async () => {
       const postIds = Array.from({ length: 20 }, (_, i) => `${DEFAULT_AUTHOR}:post-${i + 1}`);
       await createStreamWithPosts(postIds);

--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -650,6 +650,37 @@ describe('PostStreamApplication', () => {
       expect(result.nextPageIds).toEqual([classifiedPostId, unclassifiedPostId]);
     });
 
+    it('does not flag locally tombstoned posts as relationships cache misses', async () => {
+      // A tombstoned post keeps its details row (content = DELETED) but its relationships
+      // row is deleted for good. Re-fetching can never classify it and the deleted filter
+      // drops it anyway — flagging it would issue a futile by_ids on every page load.
+      const scopedStreamId = buildContentSearchStreamId('bitcoin', 'all', DEFAULT_AUTHOR as Pubky);
+      const tombstonedPostId = `${DEFAULT_AUTHOR}:tombstoned-post`;
+      await PostDetailsModel.create({
+        id: tombstonedPostId,
+        content: DELETED,
+        kind: 'short',
+        indexed_at: BASE_TIMESTAMP,
+        uri: `https://pubky.app/${DEFAULT_AUTHOR}/pub/pubky.app/posts/${tombstonedPostId}`,
+        attachments: null,
+      });
+
+      vi.spyOn(NexusPostStreamService, 'fetch').mockResolvedValue({
+        post_keys: [tombstonedPostId],
+        last_post_score: null,
+      });
+
+      const result = await PostStreamApplication.getOrFetchStreamSlice({
+        streamId: scopedStreamId,
+        limit: 1,
+        streamHead: 0,
+        streamTail: 0,
+        viewerId: null,
+      });
+
+      expect(result.cacheMissPostIds).toEqual([]);
+    });
+
     it('should return posts from cache when available (no cursor)', async () => {
       const postIds = Array.from({ length: 20 }, (_, i) => `${DEFAULT_AUTHOR}:post-${i + 1}`);
       await createStreamWithPosts(postIds);
@@ -1462,14 +1493,14 @@ describe('PostStreamApplication', () => {
   describe('fetchMissingPostsFromNexus', () => {
     const viewerId = 'user-viewer' as Pubky;
 
-    it('should fetch and persist posts when postBatch exists', async () => {
+    it('should fetch and persist posts when postBatch exists, reporting success', async () => {
       const { cacheMissPostIds, mockNexusPosts } = createTestData(2);
       const mocks = setupDefaultMocks();
       mocks.getUserDetails.mockResolvedValue(mockAllUsersCached(2));
 
       const fetchPostsByIdsSpy = vi.spyOn(NexusPostStreamService, 'fetchByIds').mockResolvedValue(mockNexusPosts);
 
-      await PostStreamApplication.fetchMissingPostsFromNexus({
+      const hydrated = await PostStreamApplication.fetchMissingPostsFromNexus({
         cacheMissPostIds,
         viewerId,
       });
@@ -1480,6 +1511,23 @@ describe('PostStreamApplication', () => {
       });
       expect(mocks.persistPosts).toHaveBeenCalledWith({ posts: mockNexusPosts });
       expect(mocks.persistFiles).toHaveBeenCalledWith([]);
+      expect(hydrated).toBe(true);
+    });
+
+    it('reports failure without throwing when the by_ids fetch rejects', async () => {
+      // Fail-open streams render what the cache has; callers with strict
+      // post-hydration filtering must be able to tell "hydration failed"
+      // apart from "hydrated, genuinely no results".
+      const { cacheMissPostIds } = createTestData(2);
+      setupDefaultMocks();
+      vi.spyOn(NexusPostStreamService, 'fetchByIds').mockRejectedValue(new Error('network down'));
+
+      const hydrated = await PostStreamApplication.fetchMissingPostsFromNexus({
+        cacheMissPostIds,
+        viewerId,
+      });
+
+      expect(hydrated).toBe(false);
     });
 
     it('should fetch and persist users when cacheMissUserIds exist', async () => {

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -23,6 +23,7 @@ import { BookmarkModel } from '@/models/bookmark/bookmark';
 import { CompositeIdDomain, type Pubky } from '@/models/models.types';
 import { buildCompositeId, buildCompositeIdFromPubkyUri, parseCompositeId } from '@/models/models.utils';
 import { PostDetailsModel } from '@/models/post/details/postDetails';
+import { DELETED } from '@/models/post/details/postDetails.constants';
 import type { PostRelationshipsModelSchema } from '@/models/post/relationships/postRelationships.schema';
 import {
   isAuthorScopedContentSearchStream,
@@ -563,8 +564,11 @@ export class PostStreamApplication {
    * @param viewerId - ID of the viewer
    * @param streamHead - Detects if the call is coming from the streamCoordinator.
    * @param streamId - ID of the stream. If not provided, it means that it is a single post operation.
+   * @returns Whether hydration succeeded. Failure is non-fatal for fail-open streams
+   * (they render what the cache has), but callers with strict post-hydration
+   * filtering (author-scoped content search) must not mistake it for "no results".
    */
-  static async fetchMissingPostsFromNexus({ cacheMissPostIds, viewerId }: TMissingPostsParams) {
+  static async fetchMissingPostsFromNexus({ cacheMissPostIds, viewerId }: TMissingPostsParams): Promise<boolean> {
     try {
       const postBatch = await NexusPostStreamService.fetchByIds({
         post_ids: cacheMissPostIds,
@@ -580,8 +584,10 @@ export class PostStreamApplication {
         .map((post) => post.relationships.reposted)
         .filter((uri): uri is string => uri !== null);
       await this.fetchOriginalPostsByUris({ repostedUris, viewerId });
+      return true;
     } catch (error) {
       Logger.warn('Failed to fetch missing posts from Nexus', { cacheMissPostIds, viewerId, error });
+      return false;
     }
   }
 
@@ -775,8 +781,16 @@ export class PostStreamApplication {
       return missingDetailsIds;
     }
 
-    const relationships = await LocalPostService.readRelationshipsByIds(postIds);
-    const missingRelationshipsIds = postIds.filter((_postId, index) => !relationships[index]);
+    const [details, relationships] = await Promise.all([
+      LocalPostService.readDetailsByIds(postIds),
+      LocalPostService.readRelationshipsByIds(postIds),
+    ]);
+    // A locally tombstoned post keeps its details row but its relationships row is gone
+    // for good: re-fetching can never classify it, and the deleted filter drops it
+    // anyway, so flagging it would issue a futile by_ids request on every page load.
+    const missingRelationshipsIds = postIds.filter(
+      (_postId, index) => !relationships[index] && details[index]?.content !== DELETED,
+    );
     return Array.from(new Set([...missingDetailsIds, ...missingRelationshipsIds]));
   }
 

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -25,6 +25,7 @@ import { buildCompositeId, buildCompositeIdFromPubkyUri, parseCompositeId } from
 import { PostDetailsModel } from '@/models/post/details/postDetails';
 import type { PostRelationshipsModelSchema } from '@/models/post/relationships/postRelationships.schema';
 import {
+  isAuthorScopedContentSearchStream,
   isAuthorStreamSkippingMuteFilter,
   isBookmarkStream,
   isContentSearchStream,
@@ -129,9 +130,11 @@ export class PostStreamApplication {
   static async filterStreamPosts({
     streamId,
     postIds,
+    strictReplyClassification = false,
   }: {
     streamId: PostStreamId;
     postIds: string[];
+    strictReplyClassification?: boolean;
   }): Promise<string[]> {
     // Bookmark and single-collection item feeds keep deleted posts so the post
     // component can render its deleted-state placeholder; all other streams drop them.
@@ -139,9 +142,45 @@ export class PostStreamApplication {
       ? postIds
       : await LocalPostService.filterDeletedPosts(postIds);
     const afterCollections = await this.filterCollectionsFromStream({ streamId, postIds: visiblePostIds });
+    const afterReplies = await this.filterRepliesFromAuthorScopedSearch({
+      streamId,
+      postIds: afterCollections,
+      strict: strictReplyClassification,
+    });
     // Discover drops empty collections (nothing to discover). Lives here so it is re-applied by
     // the controller's post-hydration second pass, catching ids that were fail-open on details.
-    return isDiscoverCollectionsStream(streamId) ? this.filterEmptyCollections(afterCollections) : afterCollections;
+    return isDiscoverCollectionsStream(streamId) ? this.filterEmptyCollections(afterReplies) : afterReplies;
+  }
+
+  /**
+   * Profile "Filter posts" (author-scoped content search) excludes replies, but the by_content
+   * endpoint cannot exclude them server-side. Classify via the local relationships row: a post
+   * with `replied !== null` is a reply. Pre-hydration (`strict = false`) posts without a
+   * relationships row are kept so the cache-miss hydration can classify them; post-hydration
+   * (`strict = true`) unclassifiable posts are dropped — degraded mode hides a result rather
+   * than ever rendering a possible reply on the Posts tab.
+   */
+  private static async filterRepliesFromAuthorScopedSearch({
+    streamId,
+    postIds,
+    strict,
+  }: {
+    streamId: PostStreamId;
+    postIds: string[];
+    strict: boolean;
+  }): Promise<string[]> {
+    if (postIds.length === 0 || !isAuthorScopedContentSearchStream(streamId)) {
+      return postIds;
+    }
+
+    const relationships = await LocalPostService.readRelationshipsByIds(postIds);
+    return postIds.filter((_postId, index) => {
+      const relationship = relationships[index];
+      if (!relationship) {
+        return !strict;
+      }
+      return relationship.replied === null;
+    });
   }
 
   /** Drop collections with zero items. Fail-open when local details are missing. */
@@ -702,7 +741,7 @@ export class PostStreamApplication {
       });
     }
 
-    const cacheMissPostIds = await this.getNotPersistedPostsInCache(compositePostIds);
+    const cacheMissPostIds = await this.getCacheMissPostIds(streamId, compositePostIds);
 
     // reachedEnd is true when Nexus returned fewer posts than requested (actual end of stream).
     // Content search also ends when the NEXT offset (this skip + raw ids consumed) would
@@ -724,6 +763,23 @@ export class PostStreamApplication {
     return LocalStreamPostsService.getNotPersistedPostsInCache(postIds);
   }
 
+  /**
+   * Cache-miss detection for a fetched stream page. Author-scoped content search additionally
+   * treats a missing relationships row as a miss: reply exclusion classifies via
+   * `relationships.replied`, so a details-cached post without one must still be hydrated —
+   * otherwise it would stay fail-open (or be dropped by the strict second pass) forever.
+   */
+  private static async getCacheMissPostIds(streamId: PostStreamId, postIds: string[]): Promise<string[]> {
+    const missingDetailsIds = await this.getNotPersistedPostsInCache(postIds);
+    if (postIds.length === 0 || !isAuthorScopedContentSearchStream(streamId)) {
+      return missingDetailsIds;
+    }
+
+    const relationships = await LocalPostService.readRelationshipsByIds(postIds);
+    const missingRelationshipsIds = postIds.filter((_postId, index) => !relationships[index]);
+    return Array.from(new Set([...missingDetailsIds, ...missingRelationshipsIds]));
+  }
+
   private static async filterCollectionsFromStream({
     streamId,
     postIds,
@@ -741,6 +797,11 @@ export class PostStreamApplication {
 
   /** Collections appear only on streams whose id encodes `kind=collection` (e.g. timeline:all:collection). */
   private static shouldExcludeCollectionsFromStream(streamId: PostStreamId): boolean {
+    // Profile search inherits the Posts tab contract: collections have their own tab.
+    if (isAuthorScopedContentSearchStream(streamId)) {
+      return true;
+    }
+
     // Content search is the one family where `kind=all` means "including
     // collections". Narrower kinds (image, video, …) fall through and keep the
     // local collection filter as defense-in-depth, like every other family.

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -10,6 +10,7 @@ import type {
 } from '@/application/stream/posts/post.types';
 import { COLLECTIONS_DISCOVER_MAX_FETCHES_PER_LOAD } from '@/config/collections';
 import { getStreamCacheMaxAgeMs } from '@/config/nexus';
+import { CONTENT_SEARCH_MAX_SKIP } from '@/config/search';
 import {
   FORCE_FETCH_NEW_POSTS,
   NOT_FOUND_CACHED_STREAM,
@@ -665,6 +666,13 @@ export class PostStreamApplication {
     viewerId,
     order,
   }: TFetchStreamParams): Promise<TPostStreamChunkResponse> {
+    // Nexus bounds the by_content offset (skip ≤ CONTENT_SEARCH_MAX_SKIP, inclusive). A cursor
+    // already past the bound could only produce a request Nexus rejects — report the end
+    // defensively instead of issuing it.
+    if (isContentSearchStream(streamId) && streamTail > CONTENT_SEARCH_MAX_SKIP) {
+      return { nextPageIds: [], cacheMissPostIds: [], nextCursor: undefined, reachedEnd: true };
+    }
+
     const { params, invokeEndpoint, extraParams } = createPostStreamParams({
       streamId,
       streamTail,
@@ -696,12 +704,18 @@ export class PostStreamApplication {
 
     const cacheMissPostIds = await this.getNotPersistedPostsInCache(compositePostIds);
 
-    // reachedEnd is true when Nexus returned fewer posts than requested (actual end of stream)
+    // reachedEnd is true when Nexus returned fewer posts than requested (actual end of stream).
+    // Content search also ends when the NEXT offset (this skip + raw ids consumed) would
+    // overflow Nexus's inclusive skip bound: this valid page is still consumed, only the
+    // follow-up request is suppressed. A next offset landing exactly on the bound stays valid.
+    const overflowsContentSearchSkip =
+      isContentSearchStream(streamId) && streamTail + compositePostIds.length > CONTENT_SEARCH_MAX_SKIP;
+
     return {
       nextPageIds: compositePostIds,
       cacheMissPostIds,
       nextCursor: rawScore ?? undefined,
-      reachedEnd: compositePostIds.length < limit,
+      reachedEnd: compositePostIds.length < limit || overflowsContentSearchSkip,
     };
   }
 

--- a/src/core/controllers/stream/posts/post.test.ts
+++ b/src/core/controllers/stream/posts/post.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PostStreamApplication } from '@/application/stream/posts/post';
 import { NEXUS_POSTS_PER_PAGE } from '@/config/nexus';
 import type { Pubky } from '@/models/models.types';
-import { PostStreamTypes } from '@/models/stream/post/postStream.types';
+import { buildContentSearchStreamId, PostStreamTypes } from '@/models/stream/post/postStream.types';
 import { StreamOrder } from '@/services/nexus/stream/posts/postStream.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import { StreamPostsController } from './posts';
@@ -70,7 +70,9 @@ describe('StreamPostsController', () => {
         lastRawPostId,
       });
 
-      const fetchMissingPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue();
+      const fetchMissingPostsSpy = vi
+        .spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus')
+        .mockResolvedValue(true);
 
       const filterStreamPostsSpy = vi.spyOn(PostStreamApplication, 'filterStreamPosts').mockResolvedValue(nextPageIds);
 
@@ -105,6 +107,72 @@ describe('StreamPostsController', () => {
       });
     });
 
+    describe('author-scoped content search (profile "Filter posts")', () => {
+      const scopedStreamId = buildContentSearchStreamId('bitcoin', 'all', 'user-1' as Pubky);
+
+      it('rejects when hydration fails, instead of strict-dropping into a false "no results"', async () => {
+        // Cold cache: every result is a miss. If by_ids fails, no relationships rows
+        // exist and the strict pass would empty the page — masking a fetch failure
+        // as a successful zero-hit search.
+        const nextPageIds = ['user-1:post-1', 'user-1:post-2'];
+        vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
+          nextPageIds,
+          cacheMissPostIds: nextPageIds,
+          nextCursor: 2,
+        });
+        vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(false);
+        const filterStreamPostsSpy = vi.spyOn(PostStreamApplication, 'filterStreamPosts');
+
+        await expect(
+          StreamPostsController.getOrFetchStreamSlice({ streamId: scopedStreamId, streamTail: 0 }),
+        ).rejects.toMatchObject({ category: 'network' });
+        expect(filterStreamPostsSpy).not.toHaveBeenCalled();
+      });
+
+      it('keeps fail-open behavior on hydration failure for ordinary streams', async () => {
+        const nextPageIds = ['user-1:post-1', 'user-1:post-2'];
+        vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
+          nextPageIds,
+          cacheMissPostIds: ['user-1:post-2'],
+          nextCursor: 1000000,
+        });
+        vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(false);
+        vi.spyOn(PostStreamApplication, 'filterStreamPosts').mockResolvedValue(nextPageIds);
+
+        const result = await StreamPostsController.getOrFetchStreamSlice({ streamId, streamTail: 0 });
+
+        expect(result.nextPageIds).toEqual(nextPageIds);
+      });
+
+      it('runs the strict pass even when the page reports no cache misses (buffered pages)', async () => {
+        // Pages served from the overflow buffer report no misses, but can hold ids
+        // that were kept fail-open before their relationships rows were hydrated.
+        const nextPageIds = ['user-1:post-1', 'user-1:reply-1'];
+        vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
+          nextPageIds,
+          cacheMissPostIds: [],
+          nextCursor: 2,
+        });
+        const fetchMissingPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus');
+        const filterStreamPostsSpy = vi
+          .spyOn(PostStreamApplication, 'filterStreamPosts')
+          .mockResolvedValue(['user-1:post-1']);
+
+        const result = await StreamPostsController.getOrFetchStreamSlice({
+          streamId: scopedStreamId,
+          streamTail: 0,
+        });
+
+        expect(fetchMissingPostsSpy).not.toHaveBeenCalled();
+        expect(filterStreamPostsSpy).toHaveBeenCalledWith({
+          streamId: scopedStreamId,
+          postIds: nextPageIds,
+          strictReplyClassification: true,
+        });
+        expect(result.nextPageIds).toEqual(['user-1:post-1']);
+      });
+    });
+
     it('preserves lastRawPostId when the second-pass filter empties the page', async () => {
       // A page whose ids were fail-open on missing details, then all dropped after
       // hydration (e.g. a freshly-fetched run of collection posts in the home feed).
@@ -117,7 +185,7 @@ describe('StreamPostsController', () => {
         nextCursor: 2000000,
         lastRawPostId: 'user-1:coll-2',
       });
-      vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue();
+      vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(true);
       vi.spyOn(PostStreamApplication, 'filterStreamPosts').mockResolvedValue([]);
 
       const result = await StreamPostsController.getOrFetchStreamSlice({
@@ -143,7 +211,7 @@ describe('StreamPostsController', () => {
         nextCursor,
       });
 
-      vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue();
+      vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(true);
 
       vi.spyOn(PostStreamApplication, 'filterStreamPosts').mockResolvedValue(['user-1:post-1', 'user-1:post-3']);
 

--- a/src/core/controllers/stream/posts/post.test.ts
+++ b/src/core/controllers/stream/posts/post.test.ts
@@ -91,7 +91,13 @@ describe('StreamPostsController', () => {
         cacheMissPostIds,
         viewerId,
       });
-      expect(filterStreamPostsSpy).toHaveBeenCalledWith({ streamId, postIds: nextPageIds });
+      // The post-hydration second pass classifies strictly: ids still lacking a
+      // relationships row on author-scoped content search are dropped, not risked.
+      expect(filterStreamPostsSpy).toHaveBeenCalledWith({
+        streamId,
+        postIds: nextPageIds,
+        strictReplyClassification: true,
+      });
       expect(result).toEqual({
         nextPageIds,
         nextCursor,

--- a/src/core/controllers/stream/posts/posts.ts
+++ b/src/core/controllers/stream/posts/posts.ts
@@ -83,7 +83,13 @@ export class StreamPostsController {
       // Second-pass: cache-miss details are now resolved,
       // re-filter to catch posts that were fail-open in the first pass.
       // Only the visible page shrinks here — the raw anchor passes through untouched.
-      visibleIds = await PostStreamApplication.filterStreamPosts({ streamId, postIds: nextPageIds });
+      // Strict reply classification: after hydration, an author-scoped content-search
+      // result that still cannot be classified is hidden, never risked as a reply.
+      visibleIds = await PostStreamApplication.filterStreamPosts({
+        streamId,
+        postIds: nextPageIds,
+        strictReplyClassification: true,
+      });
     }
     return { nextPageIds: visibleIds, nextCursor, reachedEnd, lastRawPostId };
   }

--- a/src/core/controllers/stream/posts/posts.ts
+++ b/src/core/controllers/stream/posts/posts.ts
@@ -6,6 +6,10 @@ import type {
   TReadPostStreamChunkResponse,
   TStreamIdParams,
 } from '@/controllers/stream/posts/posts.types';
+import { NetworkErrorCode } from '@/libs/error/error.codes';
+import { Err } from '@/libs/error/error.factories';
+import { ErrorService } from '@/libs/error/error.types';
+import { isAuthorScopedContentSearchStream } from '@/models/stream/post/postStream.types';
 import type { TStreamResult } from '@/services/local/stream/posts/post.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
 
@@ -73,18 +77,35 @@ export class StreamPostsController {
         order,
       });
     let visibleIds = nextPageIds;
+    const isAuthorScopedSearch = isAuthorScopedContentSearchStream(streamId);
     // Query nexus to get the cacheMissPostIds
     if (cacheMissPostIds.length > 0) {
       // TODO: When TTL is implemented, we can return to void
-      await PostStreamApplication.fetchMissingPostsFromNexus({
+      const hydrated = await PostStreamApplication.fetchMissingPostsFromNexus({
         cacheMissPostIds,
         viewerId,
       });
-      // Second-pass: cache-miss details are now resolved,
-      // re-filter to catch posts that were fail-open in the first pass.
-      // Only the visible page shrinks here — the raw anchor passes through untouched.
-      // Strict reply classification: after hydration, an author-scoped content-search
-      // result that still cannot be classified is hidden, never risked as a reply.
+      // Author-scoped search must not degrade a hydration failure into a false
+      // "no results": on a cold cache every id is a miss, and the strict pass below
+      // would drop them all. Fail the page instead — the feed shows its error state
+      // and the cursor is not consumed, so a retry re-fetches this slice.
+      if (isAuthorScopedSearch && !hydrated) {
+        throw Err.network(NetworkErrorCode.CONNECTION_FAILED, 'Could not load search results', {
+          service: ErrorService.Nexus,
+          operation: 'StreamPostsController.getOrFetchStreamSlice',
+          context: { streamId, cacheMissCount: cacheMissPostIds.length },
+        });
+      }
+    }
+    // Second-pass: cache-miss details are now resolved,
+    // re-filter to catch posts that were fail-open in the first pass.
+    // Only the visible page shrinks here — the raw anchor passes through untouched.
+    // Strict reply classification: after hydration, an author-scoped content-search
+    // result that still cannot be classified is hidden, never risked as a reply.
+    // For author-scoped search the pass runs even with zero cache misses: pages served
+    // from the overflow buffer report no misses, but may hold ids that were kept
+    // fail-open before their relationships rows had been hydrated.
+    if (cacheMissPostIds.length > 0 || (isAuthorScopedSearch && nextPageIds.length > 0)) {
       visibleIds = await PostStreamApplication.filterStreamPosts({
         streamId,
         postIds: nextPageIds,

--- a/src/core/models/stream/post/postStream.types.test.ts
+++ b/src/core/models/stream/post/postStream.types.test.ts
@@ -12,6 +12,7 @@ import {
   buildWotDomainStreamId,
   getPostStreamKind,
   getStreamDependencyScopes,
+  isAuthorScopedContentSearchStream,
   isAuthorStreamSkippingMuteFilter,
   isBookmarkStream,
   isCollectionItemsStream,
@@ -73,23 +74,59 @@ describe('post-stream id builders', () => {
       }
     });
 
+    it('round-trips author-scoped ids (profile "Filter posts") preserving the q~ marker', () => {
+      const streamId = buildContentSearchStreamId('bitcoin: wallets & privacy', StreamKind.COLLECTION, TEST_PUBKY);
+
+      expect(streamId).toBe(`content_search:q~bitcoin%3A%20wallets%20%26%20privacy:collection:${TEST_PUBKY}`);
+      expect(isContentSearchStream(streamId)).toBe(true);
+      expect(isAuthorScopedContentSearchStream(streamId)).toBe(true);
+      expect(parseContentSearchStreamId(streamId)).toEqual({
+        query: 'bitcoin: wallets & privacy',
+        kind: StreamKind.COLLECTION,
+        author: TEST_PUBKY,
+      });
+    });
+
+    it('keeps unscoped ids unscoped and colon-carrying queries out of the author segment', () => {
+      const unscoped = buildContentSearchStreamId('key:value colons');
+      expect(isAuthorScopedContentSearchStream(unscoped)).toBe(false);
+      expect(parseContentSearchStreamId(unscoped)).toEqual({ query: 'key:value colons', kind: 'all' });
+
+      // The encoded query can never leak a ':' that would shift the author segment.
+      const scoped = buildContentSearchStreamId('key:value colons', 'all', TEST_PUBKY);
+      expect(parseContentSearchStreamId(scoped)).toEqual({
+        query: 'key:value colons',
+        kind: 'all',
+        author: TEST_PUBKY,
+      });
+    });
+
     it('rejects malformed content-search ids without throwing', () => {
       // Old-format id from before the q~ marker existed.
       expect(parseContentSearchStreamId('content_search:bitcoin:all')).toBeNull();
       // Undecodable percent-encoding.
       expect(parseContentSearchStreamId('content_search:q~%:all')).toBeNull();
       expect(parseContentSearchStreamId('content_search:q~bitcoin:not-a-kind')).toBeNull();
-      expect(parseContentSearchStreamId('content_search:q~bitcoin:all:extra')).toBeNull();
+      // Anything past the author segment is malformed.
+      expect(parseContentSearchStreamId(`content_search:q~bitcoin:all:${TEST_PUBKY}:extra`)).toBeNull();
+      // A trailing ':' (empty author segment) is malformed, not an unscoped search.
+      expect(parseContentSearchStreamId('content_search:q~bitcoin:all:')).toBeNull();
       expect(parseContentSearchStreamId('content_search:q~:all')).toBeNull();
+      expect(isAuthorScopedContentSearchStream('content_search:q~bitcoin:all:')).toBe(false);
     });
 
     it('keeps isContentSearchStream prefix-based so malformed family ids stay skip-paginated', () => {
       expect(isContentSearchStream('content_search:bitcoin:all')).toBe(true);
       expect(isContentSearchStream('content_search:q~%:all')).toBe(true);
       expect(isContentSearchStream('content_search:q~bitcoin:not-a-kind')).toBe(true);
-      expect(isContentSearchStream('content_search:q~bitcoin:all:extra')).toBe(true);
+      expect(isContentSearchStream(`content_search:q~bitcoin:all:${TEST_PUBKY}:extra`)).toBe(true);
       expect(isContentSearchStream('content_search:q~:all')).toBe(true);
       expect(isContentSearchStream('timeline:all:all')).toBe(false);
+    });
+
+    it('skips the mute filter only for author-scoped content searches (profile timeline stance)', () => {
+      expect(isAuthorStreamSkippingMuteFilter(buildContentSearchStreamId('bitcoin', 'all', TEST_PUBKY))).toBe(true);
+      expect(isAuthorStreamSkippingMuteFilter(buildContentSearchStreamId('bitcoin'))).toBe(false);
     });
   });
 
@@ -220,6 +257,7 @@ describe('post-stream id builders', () => {
 describe('isSkipPaginatedStream', () => {
   it('returns true for relevance-ordered content-search streams', () => {
     expect(isSkipPaginatedStream(buildContentSearchStreamId('bitcoin wallets'))).toBe(true);
+    expect(isSkipPaginatedStream(buildContentSearchStreamId('bitcoin wallets', 'all', TEST_PUBKY))).toBe(true);
   });
 
   it('returns true for engagement streams (no stable score cursor)', () => {
@@ -278,6 +316,9 @@ describe('getPostStreamKind', () => {
   it('extracts the kind from content-search streams', () => {
     expect(getPostStreamKind(buildContentSearchStreamId('bitcoin', StreamKind.COLLECTION))).toBe(StreamKind.COLLECTION);
     expect(getPostStreamKind(buildContentSearchStreamId('bitcoin'))).toBe('all');
+    expect(getPostStreamKind(buildContentSearchStreamId('bitcoin', StreamKind.COLLECTION, TEST_PUBKY))).toBe(
+      StreamKind.COLLECTION,
+    );
   });
 
   it('extracts the kind from sorting-first stream ids', () => {

--- a/src/core/models/stream/post/postStream.types.ts
+++ b/src/core/models/stream/post/postStream.types.ts
@@ -139,8 +139,10 @@ export const CONTENT_SEARCH_STREAM_PREFIX = 'content_search' as const;
 // The marker plus encodeURIComponent (which escapes ':') guarantees the query segment can never
 // satisfy any legacy segment-based classifier (reserved words like 'bookmarks'/'author'/'wot').
 const CONTENT_SEARCH_QUERY_MARKER = 'q~' as const;
+// Optional trailing author segment scopes the search to one profile's posts (profile "Filter
+// posts"): `content_search:q~<encodedQuery>:<kind>[:<authorPubky>]`. Pubkys contain no ':'.
 export type ContentSearchStreamId =
-  `${typeof CONTENT_SEARCH_STREAM_PREFIX}:${typeof CONTENT_SEARCH_QUERY_MARKER}${string}:${PostStreamKindSegment}`;
+  `${typeof CONTENT_SEARCH_STREAM_PREFIX}:${typeof CONTENT_SEARCH_QUERY_MARKER}${string}:${PostStreamKindSegment}${'' | `:${string}`}`;
 
 export function buildPostReplyStreamId(compositePostId: string): ReplyStreamCompositeId {
   return `${StreamSource.REPLIES}:${compositePostId}`;
@@ -177,13 +179,15 @@ export function buildAuthorCollectionsStreamId(authorPubky: Pubky): AuthorCollec
 /**
  * Author-scoped profile streams intentionally include posts from muted users
  * (viewing someone's profile shows their full timeline, same as bookmarks #1804).
+ * Author-scoped content search filters that same profile timeline, so it inherits the stance.
  */
 export function isAuthorStreamSkippingMuteFilter(streamId: string): boolean {
   const [firstSegment, secondSegment] = streamId.split(':');
   return (
     firstSegment === StreamSource.AUTHOR ||
     firstSegment === StreamSource.AUTHOR_REPLIES ||
-    secondSegment === StreamSource.AUTHOR
+    secondSegment === StreamSource.AUTHOR ||
+    isAuthorScopedContentSearchStream(streamId)
   );
 }
 
@@ -204,25 +208,38 @@ export function buildCollectionItemsStreamId(authorPubky: Pubky, postId: string)
   return `${StreamSource.COLLECTION}:${authorPubky}:${postId}`;
 }
 
-export function buildContentSearchStreamId(query: string, kind: PostStreamKindSegment = 'all'): ContentSearchStreamId {
-  return `${CONTENT_SEARCH_STREAM_PREFIX}:${CONTENT_SEARCH_QUERY_MARKER}${encodeURIComponent(query)}:${kind}`;
+export function buildContentSearchStreamId(
+  query: string,
+  kind: PostStreamKindSegment = 'all',
+  author?: Pubky,
+): ContentSearchStreamId {
+  const base =
+    `${CONTENT_SEARCH_STREAM_PREFIX}:${CONTENT_SEARCH_QUERY_MARKER}${encodeURIComponent(query)}:${kind}` as const;
+  return author ? `${base}:${author}` : base;
 }
 
-export function parseContentSearchStreamId(streamId: string): { query: string; kind: PostStreamKindSegment } | null {
-  const [prefix, markedQuery, kind, ...extra] = streamId.split(':');
+export function parseContentSearchStreamId(
+  streamId: string,
+): { query: string; kind: PostStreamKindSegment; author?: Pubky } | null {
+  const [prefix, markedQuery, kind, author, ...extra] = streamId.split(':');
   const parsedKind = toPostStreamKindSegment(kind);
   if (
     prefix !== CONTENT_SEARCH_STREAM_PREFIX ||
     !markedQuery?.startsWith(CONTENT_SEARCH_QUERY_MARKER) ||
     !parsedKind ||
-    extra.length > 0
+    extra.length > 0 ||
+    // A trailing ':' (empty author segment) is malformed, not an unscoped search.
+    author === ''
   ) {
     return null;
   }
 
   try {
     const query = decodeURIComponent(markedQuery.slice(CONTENT_SEARCH_QUERY_MARKER.length));
-    return query ? { query, kind: parsedKind } : null;
+    if (!query) {
+      return null;
+    }
+    return author ? { query, kind: parsedKind, author } : { query, kind: parsedKind };
   } catch {
     return null;
   }
@@ -235,6 +252,15 @@ export function parseContentSearchStreamId(streamId: string): { query: string; k
  */
 export function isContentSearchStream(streamId: string): streamId is ContentSearchStreamId {
   return streamId.startsWith(`${CONTENT_SEARCH_STREAM_PREFIX}:`);
+}
+
+/**
+ * Author-scoped content-search streams (`content_search:q~…:<kind>:<author>`) back the profile
+ * "Filter posts" bar. They inherit profile-tab semantics — no mute filter, no collections —
+ * unlike the global (unscoped) content search.
+ */
+export function isAuthorScopedContentSearchStream(streamId: string): boolean {
+  return parseContentSearchStreamId(streamId)?.author !== undefined;
 }
 
 export function isCollectionItemsStream(streamId: string): streamId is CollectionItemsStreamCompositeId {

--- a/src/core/services/nexus/search/search.types.ts
+++ b/src/core/services/nexus/search/search.types.ts
@@ -18,6 +18,8 @@ export type TPrefixSearchParams = TPaginationParams & {
 export type TContentSearchParams = TPaginationParams & {
   q: string;
   kind?: StreamKind;
+  // Scopes the full-text search to one author's posts (profile "Filter posts").
+  author?: Pubky;
 };
 
 export type TContentSearchResult = Array<{

--- a/src/core/services/nexus/stream/posts/postStream.test.ts
+++ b/src/core/services/nexus/stream/posts/postStream.test.ts
@@ -714,6 +714,21 @@ describe('createPostStreamParams', () => {
         expect(result.params.skip).toBe(10); // NOT decremented
         expect(result.params.start).toBeUndefined();
       });
+
+      it('should carry the author scope through extraParams (profile "Filter posts")', () => {
+        const authorPubky = 'profile-author-pubky' as Pubky;
+        const result = createPostStreamParams({
+          streamId: buildContentSearchStreamId('bitcoin wallet', 'all', authorPubky),
+          streamTail: 10,
+          streamHead: 0,
+          limit: 2,
+          viewerId: mockViewerId,
+        });
+
+        expect(result.invokeEndpoint).toBe(StreamSource.CONTENT_SEARCH);
+        expect(result.extraParams).toEqual({ q: 'bitcoin wallet', author_id: authorPubky });
+        expect(result.params).toEqual({ limit: 2, skip: 10 });
+      });
     });
   });
 
@@ -1171,6 +1186,14 @@ describe('breakDownStreamId', () => {
       expect(result.kind).toBeUndefined();
       expect(result.searchQuery).toBeUndefined();
     });
+
+    it('should surface the author scope for author-scoped ids (profile "Filter posts")', () => {
+      const authorPubky = 'profile-author-pubky' as Pubky;
+      const result = breakDownStreamId(buildContentSearchStreamId('bitcoin wallet', 'all', authorPubky));
+      expect(result.invokeEndpoint).toBe(StreamSource.CONTENT_SEARCH);
+      expect(result.searchQuery).toBe('bitcoin wallet');
+      expect(result.authorId).toBe(authorPubky);
+    });
   });
 });
 
@@ -1314,6 +1337,32 @@ describe('NexusPostStreamService', () => {
 
       const calledArgs = queryNexusSpy.mock.calls[0][0] as { url: string };
       expect(calledArgs.url).not.toContain('kind=');
+    });
+
+    it('forwards the author scope into the by_content URL (profile "Filter posts")', async () => {
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue([]);
+
+      await NexusPostStreamService.fetch({
+        params: { skip: 0, limit: 2 },
+        invokeEndpoint: StreamSource.CONTENT_SEARCH,
+        extraParams: { q: 'bitcoin wallet', author_id: mockAuthorId },
+      });
+
+      const calledArgs = queryNexusSpy.mock.calls[0][0] as { url: string };
+      expect(calledArgs.url).toContain(`author=${mockAuthorId}`);
+    });
+
+    it('omits author from the URL for the global (unscoped) search', async () => {
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue([]);
+
+      await NexusPostStreamService.fetch({
+        params: { skip: 0, limit: 2 },
+        invokeEndpoint: StreamSource.CONTENT_SEARCH,
+        extraParams: { q: 'bitcoin wallet' },
+      });
+
+      const calledArgs = queryNexusSpy.mock.calls[0][0] as { url: string };
+      expect(calledArgs.url).not.toContain('author=');
     });
   });
 

--- a/src/core/services/nexus/stream/posts/postStream.ts
+++ b/src/core/services/nexus/stream/posts/postStream.ts
@@ -85,6 +85,8 @@ export class NexusPostStreamService {
         }
         const url = searchApi.byContent({
           q: extraParams.q,
+          // Present only for author-scoped searches (profile "Filter posts").
+          author: extraParams.author_id,
           kind: params.kind,
           skip: params.skip,
           limit: params.limit,

--- a/src/core/services/nexus/stream/posts/postStream.utils.ts
+++ b/src/core/services/nexus/stream/posts/postStream.utils.ts
@@ -45,8 +45,9 @@ export function createPostStreamParams({
   const { sorting, invokeEndpoint, authorId, kind, tags, wotDepth, domainTags, searchQuery } =
     breakDownStreamId(streamId);
 
-  // Content search hits its own endpoint with a minimal param surface (q, kind, skip, limit):
-  // no viewer/sorting/order/tags, and no author_id fabrication via handleNotCommonStreamParams.
+  // Content search hits its own endpoint with a minimal param surface (q, author, kind, skip,
+  // limit): no viewer/sorting/order/tags, and no author_id fabrication via
+  // handleNotCommonStreamParams. `author_id` is set only for author-scoped searches.
   if (invokeEndpoint === StreamSource.CONTENT_SEARCH) {
     const params: TStreamBase = {};
     const parsedKind = kind ? parseContent(kind) : undefined;
@@ -55,7 +56,7 @@ export function createPostStreamParams({
     }
     params.limit = limit;
     setStreamPagination({ params, streamTail, streamHead, invokeEndpoint });
-    return { params, invokeEndpoint, extraParams: { q: searchQuery } };
+    return { params, invokeEndpoint, extraParams: { q: searchQuery, author_id: authorId } };
   }
 
   const params: TStreamBase = {};
@@ -183,6 +184,8 @@ export function breakDownStreamId(streamId: PostStreamId): TStreamIdBreakdown {
       invokeEndpoint: StreamSource.CONTENT_SEARCH,
       kind: contentSearch?.kind,
       searchQuery: contentSearch?.query,
+      // Author-scoped searches (profile "Filter posts") carry the profile pubky.
+      authorId: contentSearch?.author,
     };
   }
 

--- a/src/hooks/useDeletePost/useDeletePost.test.tsx
+++ b/src/hooks/useDeletePost/useDeletePost.test.tsx
@@ -340,6 +340,93 @@ describe('useDeletePost', () => {
     });
   });
 
+  describe('transactional removal (feeds exposing removePostsOptimistically)', () => {
+    // These feeds route deletes through the commit/rollback transaction so the
+    // skip-stream cursor decrement (owned by useStreamPagination) is applied on
+    // commit. The suite above keeps covering the legacy removePosts fallback.
+    const mockCommit = vi.fn();
+    const mockRollback = vi.fn();
+    const mockRemovePostsOptimistically = vi.fn(() => ({ commit: mockCommit, rollback: mockRollback }));
+    const transactionalFeed = {
+      ...mockTimelineFeed,
+      removePostsOptimistically: mockRemovePostsOptimistically,
+    };
+
+    beforeEach(() => {
+      vi.mocked(useTimelineFeedContext).mockReturnValue(transactionalFeed);
+    });
+
+    it('opens the removal before the delete and commits it on success', async () => {
+      mockDelete.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useDeletePost());
+      await act(async () => {
+        await result.current.deletePost(mockPostId);
+      });
+
+      expect(mockRemovePostsOptimistically).toHaveBeenCalledWith(mockPostId);
+      expect(mockRemovePostsOptimistically).toHaveBeenCalledBefore(mockDelete);
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+      expect(mockRollback).not.toHaveBeenCalled();
+      // The transactional path replaces the plain removal entirely.
+      expect(mockRemovePosts).not.toHaveBeenCalled();
+    });
+
+    it('commits the removal when the sync fails but the local row is tombstoned', async () => {
+      mockDelete.mockRejectedValue(new Error('homeserver sync failed'));
+      mockGetPostDetails.mockResolvedValue({ id: mockPostId, content: '[DELETED]' });
+
+      const { result } = renderHook(() => useDeletePost());
+      await act(async () => {
+        await result.current.deletePost(mockPostId);
+      });
+
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+      expect(mockRollback).not.toHaveBeenCalled();
+    });
+
+    it('commits the removal when the sync fails but the local row is gone (hard delete)', async () => {
+      mockDelete.mockRejectedValue(new Error('homeserver sync failed'));
+      mockGetPostDetails.mockResolvedValue(null);
+
+      const { result } = renderHook(() => useDeletePost());
+      await act(async () => {
+        await result.current.deletePost(mockPostId);
+      });
+
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+      expect(mockRollback).not.toHaveBeenCalled();
+    });
+
+    it('rolls back the removal when the sync fails and the local row is still live', async () => {
+      mockDelete.mockRejectedValue(new Error('deletion failed'));
+      mockGetPostDetails.mockResolvedValue({ id: mockPostId, content: 'Test post' });
+
+      const { result } = renderHook(() => useDeletePost());
+      await act(async () => {
+        await result.current.deletePost(mockPostId);
+      });
+
+      expect(mockRollback).toHaveBeenCalledTimes(1);
+      expect(mockCommit).not.toHaveBeenCalled();
+      // Rollback reveals the card in place; no prepend-based restore.
+      expect(mockPrependPosts).not.toHaveBeenCalled();
+    });
+
+    it('rolls back the removal when the local state cannot be verified', async () => {
+      mockDelete.mockRejectedValue(new Error('deletion failed'));
+      mockGetPostDetails.mockRejectedValue(new Error('indexeddb unavailable'));
+
+      const { result } = renderHook(() => useDeletePost());
+      await act(async () => {
+        await result.current.deletePost(mockPostId);
+      });
+
+      expect(mockRollback).toHaveBeenCalledTimes(1);
+      expect(mockCommit).not.toHaveBeenCalled();
+    });
+  });
+
   describe('toastMessages override', () => {
     it('uses overridden success toast copy when provided', async () => {
       mockDelete.mockResolvedValue(undefined);

--- a/src/hooks/useDeletePost/useDeletePost.tsx
+++ b/src/hooks/useDeletePost/useDeletePost.tsx
@@ -57,14 +57,21 @@ export function useDeletePost(options?: UseDeletePostOptions): UseDeletePostResu
 
     setIsDeleting(true);
 
-    // Optimistically remove post from timeline feed
-    timelineFeed?.removePosts(postId);
+    // Optimistically remove the post as a transaction: the commit path also decrements
+    // skip-stream offsets (content search, engagement, collections), so the next page
+    // doesn't skip one live row once Nexus drops the deleted post. The plain removePosts
+    // fallback covers providers that don't expose the transactional API.
+    const removal = timelineFeed?.removePostsOptimistically?.(postId);
+    if (!removal) {
+      timelineFeed?.removePosts(postId);
+    }
 
     try {
       await PostController.commitDelete({ compositePostId: postId });
       // Clear the optimistic attachment cache so its blob URLs are revoked and
       // don't shadow the tombstone for the rest of the session
       useLocalFilesStore.getState().setPostAttachments(postId, []);
+      removal?.commit();
       Logger.info('[useDeletePost] Post deleted successfully', { postId });
       toast({
         title: deletedTitle,
@@ -111,11 +118,12 @@ export function useDeletePost(options?: UseDeletePostOptions): UseDeletePostResu
         postStillExists === null || (postStillExists !== 'unknown' && isPostDeleted(postStillExists.content));
 
       if (localWriteCommitted) {
-        // Local-first write succeeded (row gone or tombstoned). Leave the
-        // optimistic removal in place — homeserver retry can resync. The
-        // optimistic attachment cache is cleared here too (as on success): the
-        // post renders as deleted either way, so its blob URLs are dead weight.
+        // Local-first write succeeded (row gone or tombstoned). Keep the removal —
+        // committing also applies the cursor decrement, matching local state; the
+        // homeserver retry can resync later. Clear the optimistic attachment cache
+        // too, because the post renders as deleted and its blob URLs are dead weight.
         useLocalFilesStore.getState().setPostAttachments(postId, []);
+        removal?.commit();
         Logger.warn('[useDeletePost] Local write committed; not restoring to timeline', {
           postId,
           state: postStillExists === null ? 'row_removed' : 'tombstoned',
@@ -123,8 +131,13 @@ export function useDeletePost(options?: UseDeletePostOptions): UseDeletePostResu
         });
       } else {
         // Either we couldn't verify, or the row exists with original content
-        // (local-first never committed). Put the card back.
-        timelineFeed?.prependPosts(postId);
+        // (local-first never committed). Put the card back: rollback reveals it in
+        // place; the prepend fallback re-inserts it for non-transactional providers.
+        if (removal) {
+          removal.rollback();
+        } else {
+          timelineFeed?.prependPosts(postId);
+        }
         Logger.info('[useDeletePost] Post restored to timeline after failed deletion', {
           postId,
           reason: postStillExists === 'unknown' ? 'could_not_verify' : 'local_write_did_not_commit',

--- a/src/hooks/useProfilePostsFilter/useProfilePostsFilter.constants.ts
+++ b/src/hooks/useProfilePostsFilter/useProfilePostsFilter.constants.ts
@@ -1,0 +1,2 @@
+/** Debounce delay before an edited filter query hits Nexus (same cadence as autocomplete). */
+export const PROFILE_POSTS_FILTER_DEBOUNCE_MS = 500;

--- a/src/hooks/useProfilePostsFilter/useProfilePostsFilter.constants.ts
+++ b/src/hooks/useProfilePostsFilter/useProfilePostsFilter.constants.ts
@@ -1,2 +1,2 @@
-/** Debounce delay before an edited filter query hits Nexus (same cadence as autocomplete). */
+/** Debounce delay before an edited filter query hits Nexus. */
 export const PROFILE_POSTS_FILTER_DEBOUNCE_MS = 500;

--- a/src/hooks/useProfilePostsFilter/useProfilePostsFilter.test.tsx
+++ b/src/hooks/useProfilePostsFilter/useProfilePostsFilter.test.tsx
@@ -1,0 +1,139 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProfilePostsFilter } from './useProfilePostsFilter';
+import { PROFILE_POSTS_FILTER_DEBOUNCE_MS } from './useProfilePostsFilter.constants';
+
+describe('useProfilePostsFilter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts idle with an empty input and no active query', () => {
+    const { result } = renderHook(() => useProfilePostsFilter());
+
+    expect(result.current.inputValue).toBe('');
+    expect(result.current.activeQuery).toBeNull();
+  });
+
+  it('debounces the query: inactive while typing, active after the delay', () => {
+    const { result } = renderHook(() => useProfilePostsFilter());
+
+    act(() => {
+      result.current.onInputChange('bitcoin');
+    });
+    expect(result.current.inputValue).toBe('bitcoin');
+    expect(result.current.activeQuery).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(PROFILE_POSTS_FILTER_DEBOUNCE_MS - 1);
+    });
+    expect(result.current.activeQuery).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.activeQuery).toBe('bitcoin');
+  });
+
+  it('restarts the debounce on every keystroke (only the final value applies)', () => {
+    const { result } = renderHook(() => useProfilePostsFilter());
+
+    act(() => {
+      result.current.onInputChange('bit');
+    });
+    act(() => {
+      vi.advanceTimersByTime(PROFILE_POSTS_FILTER_DEBOUNCE_MS - 100);
+    });
+    act(() => {
+      result.current.onInputChange('bitcoin');
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    // The first keystroke's timer was superseded, not fired.
+    expect(result.current.activeQuery).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(PROFILE_POSTS_FILTER_DEBOUNCE_MS);
+    });
+    expect(result.current.activeQuery).toBe('bitcoin');
+  });
+
+  it('applies the validator: trims the query and rejects invalid input as null', () => {
+    const { result } = renderHook(() => useProfilePostsFilter());
+
+    const applyInput = (value: string) => {
+      act(() => {
+        result.current.onInputChange(value);
+      });
+      act(() => {
+        vi.advanceTimersByTime(PROFILE_POSTS_FILTER_DEBOUNCE_MS);
+      });
+    };
+
+    applyInput('  bitcoin wallet  ');
+    expect(result.current.activeQuery).toBe('bitcoin wallet');
+
+    // Below the 2-char minimum.
+    applyInput('a');
+    expect(result.current.activeQuery).toBeNull();
+
+    // Above the 30-char maximum.
+    applyInput('a'.repeat(31));
+    expect(result.current.activeQuery).toBeNull();
+
+    // Above the 4-term maximum.
+    applyInput('one two three four five');
+    expect(result.current.activeQuery).toBeNull();
+  });
+
+  it('clears immediately: cancels the pending debounce and resets the active query', () => {
+    const { result } = renderHook(() => useProfilePostsFilter());
+
+    act(() => {
+      result.current.onInputChange('bitcoin');
+    });
+    act(() => {
+      vi.advanceTimersByTime(PROFILE_POSTS_FILTER_DEBOUNCE_MS);
+    });
+    expect(result.current.activeQuery).toBe('bitcoin');
+
+    act(() => {
+      result.current.onInputChange('bitcoin wallets');
+    });
+    act(() => {
+      result.current.onInputChange('');
+    });
+    // No debounce lag on clear: the ordinary feed is back at once…
+    expect(result.current.activeQuery).toBeNull();
+
+    // …and the pending 'bitcoin wallets' apply was canceled, so nothing
+    // resurrects the search after the delay.
+    act(() => {
+      vi.advanceTimersByTime(PROFILE_POSTS_FILTER_DEBOUNCE_MS * 2);
+    });
+    expect(result.current.activeQuery).toBeNull();
+    expect(result.current.inputValue).toBe('');
+  });
+
+  it('treats whitespace-only input as a clear', () => {
+    const { result } = renderHook(() => useProfilePostsFilter());
+
+    act(() => {
+      result.current.onInputChange('bitcoin');
+    });
+    act(() => {
+      vi.advanceTimersByTime(PROFILE_POSTS_FILTER_DEBOUNCE_MS);
+    });
+    expect(result.current.activeQuery).toBe('bitcoin');
+
+    act(() => {
+      result.current.onInputChange('   ');
+    });
+    expect(result.current.activeQuery).toBeNull();
+  });
+});

--- a/src/hooks/useProfilePostsFilter/useProfilePostsFilter.test.tsx
+++ b/src/hooks/useProfilePostsFilter/useProfilePostsFilter.test.tsx
@@ -91,6 +91,40 @@ describe('useProfilePostsFilter', () => {
     expect(result.current.activeQuery).toBeNull();
   });
 
+  it('exposes the validator message for a settled invalid query and clears it again', () => {
+    const { result } = renderHook(() => useProfilePostsFilter());
+
+    const applyInput = (value: string) => {
+      act(() => {
+        result.current.onInputChange(value);
+      });
+      act(() => {
+        vi.advanceTimersByTime(PROFILE_POSTS_FILTER_DEBOUNCE_MS);
+      });
+    };
+
+    expect(result.current.validationMessage).toBeNull();
+
+    applyInput('one two three four five');
+    expect(result.current.activeQuery).toBeNull();
+    expect(result.current.validationMessage).toMatch(/up to 4 terms/);
+
+    // A valid query replaces the message with an active filter.
+    applyInput('bitcoin');
+    expect(result.current.activeQuery).toBe('bitcoin');
+    expect(result.current.validationMessage).toBeNull();
+
+    // While typing (debounce pending) the previous message state holds; no flicker.
+    applyInput('a');
+    expect(result.current.validationMessage).toMatch(/at least 2 characters/);
+
+    // Clearing resets the message synchronously, like the active query.
+    act(() => {
+      result.current.onInputChange('');
+    });
+    expect(result.current.validationMessage).toBeNull();
+  });
+
   it('clears immediately: cancels the pending debounce and resets the active query', () => {
     const { result } = renderHook(() => useProfilePostsFilter());
 

--- a/src/hooks/useProfilePostsFilter/useProfilePostsFilter.ts
+++ b/src/hooks/useProfilePostsFilter/useProfilePostsFilter.ts
@@ -12,17 +12,26 @@ import type { UseProfilePostsFilterResult } from './useProfilePostsFilter.types'
  * Owns the raw input value and derives `activeQuery` from it: debounced while
  * typing, validated through the shared content-search rules (2–30 chars, max
  * 4 terms). Invalid or empty input yields `null`, keeping the ordinary
- * profile feed. No pagination logic lives here — the caller swaps the stream
- * id and `useStreamPagination` does the rest.
+ * profile feed; for invalid non-empty input the validator's message is exposed
+ * as `validationMessage` so the bar can say why no filter is applied. No
+ * pagination logic lives here — the caller swaps the stream id and
+ * `useStreamPagination` does the rest.
  */
 export function useProfilePostsFilter(): UseProfilePostsFilterResult {
   const [inputValue, setInputValue] = useState('');
   const [activeQuery, setActiveQuery] = useState<string | null>(null);
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
 
   const debouncedApplyRef = useRef(
     debounce((rawValue: string) => {
       const validation = validateContentSearchQuery(rawValue);
-      setActiveQuery(validation.isValid ? validation.query : null);
+      if (validation.isValid) {
+        setActiveQuery(validation.query);
+        setValidationMessage(null);
+      } else {
+        setActiveQuery(null);
+        setValidationMessage(validation.message);
+      }
     }, PROFILE_POSTS_FILTER_DEBOUNCE_MS),
   );
 
@@ -38,10 +47,11 @@ export function useProfilePostsFilter(): UseProfilePostsFilterResult {
       // cleared bar can never flash stale search results after the delay.
       debouncedApplyRef.current.cancel();
       setActiveQuery(null);
+      setValidationMessage(null);
       return;
     }
     debouncedApplyRef.current(value);
   };
 
-  return { inputValue, onInputChange, activeQuery };
+  return { inputValue, onInputChange, activeQuery, validationMessage };
 }

--- a/src/hooks/useProfilePostsFilter/useProfilePostsFilter.ts
+++ b/src/hooks/useProfilePostsFilter/useProfilePostsFilter.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { debounce } from 'lodash-es';
+import { validateContentSearchQuery } from '@/libs/search/contentSearch';
+import { PROFILE_POSTS_FILTER_DEBOUNCE_MS } from './useProfilePostsFilter.constants';
+import type { UseProfilePostsFilterResult } from './useProfilePostsFilter.types';
+
+/**
+ * State for the profile "Filter posts" bar.
+ *
+ * Owns the raw input value and derives `activeQuery` from it: debounced while
+ * typing, validated through the shared content-search rules (2–30 chars, max
+ * 4 terms). Invalid or empty input yields `null`, keeping the ordinary
+ * profile feed. No pagination logic lives here — the caller swaps the stream
+ * id and `useStreamPagination` does the rest.
+ */
+export function useProfilePostsFilter(): UseProfilePostsFilterResult {
+  const [inputValue, setInputValue] = useState('');
+  const [activeQuery, setActiveQuery] = useState<string | null>(null);
+
+  const debouncedApplyRef = useRef(
+    debounce((rawValue: string) => {
+      const validation = validateContentSearchQuery(rawValue);
+      setActiveQuery(validation.isValid ? validation.query : null);
+    }, PROFILE_POSTS_FILTER_DEBOUNCE_MS),
+  );
+
+  useEffect(() => {
+    const debouncedApply = debouncedApplyRef.current;
+    return () => debouncedApply.cancel();
+  }, []);
+
+  const onInputChange = (value: string) => {
+    setInputValue(value);
+    if (!value.trim()) {
+      // Clearing takes effect immediately: cancel the pending debounce so a
+      // cleared bar can never flash stale search results after the delay.
+      debouncedApplyRef.current.cancel();
+      setActiveQuery(null);
+      return;
+    }
+    debouncedApplyRef.current(value);
+  };
+
+  return { inputValue, onInputChange, activeQuery };
+}

--- a/src/hooks/useProfilePostsFilter/useProfilePostsFilter.types.ts
+++ b/src/hooks/useProfilePostsFilter/useProfilePostsFilter.types.ts
@@ -1,0 +1,12 @@
+export interface UseProfilePostsFilterResult {
+  /** Raw value for the controlled filter input. */
+  inputValue: string;
+  /** Input change handler; owns debounce and immediate cancel-on-clear. */
+  onInputChange: (value: string) => void;
+  /**
+   * Validated, trimmed query driving the author-scoped content-search stream,
+   * or `null` when the input is empty or invalid (too short/long, too many
+   * terms) — the ordinary profile feed stays in that case.
+   */
+  activeQuery: string | null;
+}

--- a/src/hooks/useProfilePostsFilter/useProfilePostsFilter.types.ts
+++ b/src/hooks/useProfilePostsFilter/useProfilePostsFilter.types.ts
@@ -9,4 +9,10 @@ export interface UseProfilePostsFilterResult {
    * terms) — the ordinary profile feed stays in that case.
    */
   activeQuery: string | null;
+  /**
+   * The validator's user-facing message when the settled (debounced) input is
+   * non-empty but invalid, `null` otherwise. Lets the bar explain why the feed
+   * is unfiltered instead of silently showing everything.
+   */
+  validationMessage: string | null;
 }

--- a/src/hooks/useStreamPagination/useStreamPagination.test.tsx
+++ b/src/hooks/useStreamPagination/useStreamPagination.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { StreamPostsController } from '@/controllers/stream/posts/posts';
+import type { TReadPostStreamChunkResponse } from '@/controllers/stream/posts/posts.types';
 import { PostDetailsModel } from '@/models/post/details/postDetails';
 import type { PostStreamId } from '@/models/stream/post/postStream.types';
 import { sortPostIdsByTimestamp } from '@/utils/sorting';
@@ -509,6 +510,140 @@ describe('useStreamPagination', () => {
 
       // Should still fetch for new stream
       expect(callCountAfter).toBeGreaterThan(callCountBefore);
+    });
+  });
+
+  describe('Stale in-flight requests after reset', () => {
+    const streamA = 'timeline:all:all' as PostStreamId;
+    const streamB = 'timeline:following:all' as PostStreamId;
+
+    function deferred<T>() {
+      let resolve!: (value: T) => void;
+      let reject!: (reason?: unknown) => void;
+      const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
+    }
+
+    it('ignores a late-resolving fetch for the previous stream (posts, cursor, hasMore)', async () => {
+      const staleFetch = deferred<TReadPostStreamChunkResponse>();
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockImplementation(async ({ streamId }) =>
+        streamId === streamA ? staleFetch.promise : { nextPageIds: ['b1', 'b2'], nextCursor: 20 },
+      );
+
+      const { result, rerender } = renderHook(({ streamId }) => useStreamPagination({ streamId }), {
+        initialProps: { streamId: streamA },
+      });
+
+      // Ensure A's slice request is actually in flight (not bailed at an earlier
+      // checkpoint) before switching, so the late resolution exercises the guard.
+      await waitFor(() =>
+        expect(StreamPostsController.getOrFetchStreamSlice).toHaveBeenCalledWith(
+          expect.objectContaining({ streamId: streamA }),
+        ),
+      );
+      rerender({ streamId: streamB });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.postIds).toEqual(['b1', 'b2']);
+
+      // A resolves late with its own posts, an end-of-stream marker, and a far cursor.
+      await act(async () => {
+        staleFetch.resolve({ nextPageIds: ['a1'], reachedEnd: true, nextCursor: 999 });
+      });
+
+      expect(result.current.postIds).toEqual(['b1', 'b2']);
+      expect(result.current.hasMore).toBe(true); // A's reachedEnd must not leak into B
+
+      // The next page must resume from B's cursor, not A's.
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockClear();
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValueOnce({
+        nextPageIds: ['b3'],
+        nextCursor: 21,
+      });
+      await act(async () => {
+        await result.current.loadMore();
+      });
+      expect(StreamPostsController.getOrFetchStreamSlice).toHaveBeenCalledWith(
+        expect.objectContaining({ streamId: streamB, streamTail: 20 }),
+      );
+    });
+
+    it('ignores a late-rejecting fetch for the previous stream (no error, hasMore, loading, or onError writes)', async () => {
+      const staleFetch = deferred<TReadPostStreamChunkResponse>();
+      const onError = vi.fn();
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockImplementation(async ({ streamId }) =>
+        streamId === streamA ? staleFetch.promise : { nextPageIds: ['b1'], nextCursor: 20 },
+      );
+
+      const { result, rerender } = renderHook(({ streamId }) => useStreamPagination({ streamId, onError }), {
+        initialProps: { streamId: streamA },
+      });
+
+      // The rejection must reach the hook's catch: wait until A's request is in
+      // flight, otherwise the deferred has no consumer and the rejection escapes.
+      await waitFor(() =>
+        expect(StreamPostsController.getOrFetchStreamSlice).toHaveBeenCalledWith(
+          expect.objectContaining({ streamId: streamA }),
+        ),
+      );
+      rerender({ streamId: streamB });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        staleFetch.reject(new Error('network down'));
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.hasMore).toBe(true);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.loadingMore).toBe(false);
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('does not strand loadingMore when the stream switches during an in-flight loadMore', async () => {
+      const staleLoadMore = deferred<TReadPostStreamChunkResponse>();
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice)
+        .mockResolvedValueOnce({ nextPageIds: ['a1'], nextCursor: 10 }) // A initial load
+        .mockImplementationOnce(() => staleLoadMore.promise) // A loadMore, left in flight
+        .mockResolvedValue({ nextPageIds: ['b1'], nextCursor: 20 }); // B initial load
+
+      const { result, rerender } = renderHook(({ streamId }) => useStreamPagination({ streamId }), {
+        initialProps: { streamId: streamA },
+      });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      let staleLoadMorePromise: Promise<void> = Promise.resolve();
+      act(() => {
+        staleLoadMorePromise = result.current.loadMore();
+      });
+      expect(result.current.loadingMore).toBe(true);
+
+      rerender({ streamId: streamB });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      // The reset released the flag even though the stale request never settled.
+      expect(result.current.loadingMore).toBe(false);
+
+      await act(async () => {
+        staleLoadMore.resolve({ nextPageIds: ['a2'], nextCursor: 11 });
+        await staleLoadMorePromise;
+      });
+      expect(result.current.postIds).toEqual(['b1']);
+      expect(result.current.loadingMore).toBe(false);
+
+      // Pagination on the new stream still works and resumes from B's cursor.
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockClear();
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValueOnce({
+        nextPageIds: ['b2'],
+        nextCursor: 21,
+      });
+      await act(async () => {
+        await result.current.loadMore();
+      });
+      expect(StreamPostsController.getOrFetchStreamSlice).toHaveBeenCalledWith(
+        expect.objectContaining({ streamId: streamB, streamTail: 20 }),
+      );
     });
   });
 

--- a/src/hooks/useStreamPagination/useStreamPagination.ts
+++ b/src/hooks/useStreamPagination/useStreamPagination.ts
@@ -90,6 +90,11 @@ export function useStreamPagination({
   // flight from the cursor it writes back. Reset in `clearState` (a fresh
   // fetch recounts consumed rows from scratch).
   const committedRemovalsRef = useRef(0);
+  // Monotonic token bumped by `clearState` (stream switch, refresh). A fetch snapshots it at
+  // entry and drops ALL of its state writes — success and failure — if a reset happened during
+  // its flight: a late-resolving request for a previous stream (or a pre-refresh cursor) must
+  // not overwrite the fresh stream's posts, cursors, hasMore, error, or loading flags.
+  const fetchGenerationRef = useRef(0);
   const activeStreamIdRef = useRef(streamId);
   activeStreamIdRef.current = streamId;
 
@@ -112,6 +117,8 @@ export function useStreamPagination({
       setLoadingState(isInitialLoad, true);
       setError(null);
       const committedRemovalsAtRequest = committedRemovalsRef.current;
+      const generationAtRequest = fetchGenerationRef.current;
+      const isStale = () => fetchGenerationRef.current !== generationAtRequest;
 
       try {
         let result: TReadPostStreamChunkResponse;
@@ -122,6 +129,7 @@ export function useStreamPagination({
           await StreamPostsController.prepareStreamForInitialLoad({ streamId });
 
           const cachedLastPostTimestamp = await StreamPostsController.getCachedLastPostTimestamp({ streamId });
+          if (isStale()) return;
           setStreamTail(cachedLastPostTimestamp);
 
           result = await StreamPostsController.getOrFetchStreamSlice({
@@ -139,6 +147,10 @@ export function useStreamPagination({
             limit,
           });
         }
+
+        // A reset (stream switch or refresh) during the flight makes this response stale;
+        // every write below belongs to state that no longer exists.
+        if (isStale()) return;
 
         // Advance BOTH resume cursors from the response, even on a fully-filtered (empty)
         // page: `streamTail` by the raw backend cursor, `lastPostId` (the local cache-walk
@@ -198,13 +210,20 @@ export function useStreamPagination({
         optimisticPostIdsRef.current = displayedState.optimisticPostIds;
         setPostIds(displayedState.displayedPostIds);
       } catch (err) {
+        Logger.error('Failed to fetch stream slice:', err);
+        // A stale failure belongs to a discarded request: surfacing it (error banner,
+        // hasMore=false, onError) would poison the fresh stream's state.
+        if (isStale()) return;
         const errorMessage = isAppError(err) ? err.message : 'An unknown error occurred.';
         setError(errorMessage);
         setHasMore(false);
-        Logger.error('Failed to fetch stream slice:', err);
         onError?.(err);
       } finally {
-        setLoadingState(isInitialLoad, false);
+        // The fresh stream's fetch owns the loading flags now; `clearState` already
+        // reset `loadingMore` so a skipped write here cannot strand it.
+        if (!isStale()) {
+          setLoadingState(isInitialLoad, false);
+        }
       }
     },
     [streamId, lastPostId, streamTail, limit, setLoadingState, onError],
@@ -214,6 +233,8 @@ export function useStreamPagination({
    * Clears all state
    */
   const clearState = useCallback(({ preserveOptimisticPostIds = false, preserveHiddenPostIds = false } = {}) => {
+    // Invalidate in-flight fetches: their responses describe the state being cleared here.
+    fetchGenerationRef.current += 1;
     postIdsRef.current = [];
     if (!preserveHiddenPostIds) {
       hiddenPostCountsRef.current.clear();
@@ -233,6 +254,9 @@ export function useStreamPagination({
     committedRemovalsRef.current = 0;
     setHasMore(true);
     setError(null);
+    // An in-flight loadMore just became stale and will skip its own finally-clear;
+    // without this reset the stuck flag would permanently block `loadMore`.
+    setLoadingMore(false);
   }, []);
 
   /**


### PR DESCRIPTION
## Summary

Stacked on #2377 (full-text content search) — linked as a native GitHub stack (#2377 → this PR), so this diff shows only the new commits and GitHub retargets this PR to `dev` automatically when #2377 merges.

Closes #2234.

https://github.com/user-attachments/assets/82688b7b-9608-4935-92d8-08f8a5d62a07

### Shared stream machinery hardening (first 3 commits)

- **Stale in-flight fetch guard** (`useStreamPagination`): a fetch generation counter invalidates in-flight requests on stream switch/refresh, so late-resolving responses can no longer overwrite posts/cursor/`hasMore`, surface stale errors, or strand `loadingMore`.
- **Nexus skip bound** (`PostStreamApplication`): content-search streams stop paginating at Nexus's inclusive `BoundedSkip<1000>` — requests that would exceed the bound are short-circuited and `reachedEnd` is reported when the next offset would cross it.
- **Transactional delete** (`useDeletePost`): deletes go through `removePostsOptimistically`, committing when the local row is tombstoned/gone and rolling back when it's still live or unverifiable — keeping skip-stream cursors correct after deletions.

### Profile "Filter posts" feature (last 2 commits)

- **Author-scoped content search** end to end: `content_search:q~<query>:<kind>:<author>` stream ids, `author` forwarded to `GET /v0/search/posts/by_content`, profile-tab semantics inherited (no mute filter, collections excluded).
- **Reply exclusion** via local relationships rows: fail-open before hydration, strict in the controller's post-hydration second pass; relationships-aware cache-miss detection hydrates details-cached posts that lack a relationships row.
- **UI**: `useProfilePostsFilter` hook (500ms debounce, shared 2–30 char / max 4 term validation, immediate cancel-on-clear), `FilterPostsBar` pill above the profile Posts feed (stays mounted across stream swaps, preserving input focus), and a search-specific `FilterPostsEmpty` no-results state.

### Decisions needing sign-off

- **Replies excluded** from filtered results (decided in-session; the endpoint cannot exclude them server-side). Unclassifiable posts are hidden, never shown as potential replies.
- **Collections excluded** from the scoped search — inferred from the profile Posts tab contract ("all posts except collections"); Nexus does index collection content, so please confirm.
- **No-results copy/artwork** ("No posts match your search") is a placeholder pending design confirmation — the issue/Figma document no empty state.
- No content/kind filter UI (decided in-session); relevance order only (endpoint has no sort param).

## Test plan

- [x] `useStreamPagination` race tests: late-resolving/rejecting fetches for a previous stream are ignored; `loadingMore` is not stranded
- [x] Skip-bound tests: request at offset 1000 issued; past-bound short-circuits without a Nexus call; full page crossing the bound reports `reachedEnd`
- [x] `useDeletePost` transaction tests: commit on success/tombstone/hard-delete, rollback on live/unverifiable local state
- [x] Stream id builder/parser round-trip with author segment; malformed-id cases
- [x] Service tests: `author` carried through `breakDownStreamId`/`createPostStreamParams` into the `by_content` URL; omitted for global search
- [x] Application tests: collections + reply exclusion (fail-open/strict passes), relationships-aware cache-miss detection
- [x] Hook tests: debounce, validator integration, immediate cancel-on-clear
- [x] Component tests: `FilterPostsBar`, profile stream swap idle ↔ searching, conditional empty state
- [x] Full typecheck + 890 tests across the 31 affected suites pass
- [ ] Manual pass on staging (own profile + other-user profile)
