### PR TITLE
fix(posts): render more link inline with truncated text

### DIFF
--- a/cypress/e2e/posts.cy.ts
+++ b/cypress/e2e/posts.cy.ts
@@ -95,8 +95,8 @@ describe('posts', () => {
 
     cy.findFirstPostInFeed().within(() => {
       cy.get('[data-cy="post-text"]').should('contain.text', prefix.trim());
-      cy.contains('Show more').should('be.visible').click();
-      cy.contains('Show more').should('not.exist');
+      cy.get('button[aria-label="Show full post content"]').should('be.visible').click();
+      cy.get('button[aria-label="Show full post content"]').should('not.exist');
       cy.get('[data-cy="post-text"]').should('contain.text', postContent);
     });
     cy.location('pathname').should('eq', '/home');

--- a/src/components/molecules/PostText/PostText.test.tsx
+++ b/src/components/molecules/PostText/PostText.test.tsx
@@ -949,16 +949,19 @@ describe('PostText', () => {
       expect(screen.getByRole('button', { name: 'Show full post content' })).toBeInTheDocument();
     });
 
-    it('renders "Show more" button with correct styling classes', () => {
+    it('renders the "more" button inline after the truncation ellipsis with correct styling classes', () => {
       const longContent = generateContent(600);
       render(<PostText content={longContent} />);
 
       const showMoreButton = screen.getByRole('button', { name: 'Show full post content' });
       expect(showMoreButton).not.toHaveAttribute('data-allow-post-navigation');
       expect(showMoreButton).toHaveAttribute('type', 'button');
+      expect(showMoreButton).toHaveTextContent('more');
+      expect(showMoreButton.parentElement).toHaveProperty('tagName', 'P');
+      expect(showMoreButton.previousSibling?.textContent).toMatch(/\.\.\.\u00a0$/);
       expect(showMoreButton).toHaveClass('cursor-pointer');
       expect(showMoreButton).toHaveClass('text-brand');
-      expect(showMoreButton).toHaveClass('mt-4');
+      expect(showMoreButton).not.toHaveClass('mt-4');
     });
 
     it('expands truncated content in place and stops event propagation on "Show more" click', () => {
@@ -1271,7 +1274,7 @@ Third line`}
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('matches snapshot for truncated content with Show more button', () => {
+  it('matches snapshot for truncated content with inline more button', () => {
     const longContent =
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Extra text to make this longer than 500 characters for truncation testing purposes.';
     const { container } = render(<PostText content={longContent} />);

--- a/src/components/molecules/PostText/PostText.test.tsx
+++ b/src/components/molecules/PostText/PostText.test.tsx
@@ -995,19 +995,13 @@ describe('PostText', () => {
       expect(screen.getByRole('button', { name: 'Show full post content' })).toBeInTheDocument();
     });
 
-    it('renders the "more" button inline after the truncation ellipsis with correct styling classes', () => {
+    it('renders the "more" button inline directly after the truncation ellipsis', () => {
       const longContent = generateContent(600);
       render(<PostText content={longContent} />);
 
       const showMoreButton = screen.getByRole('button', { name: 'Show full post content' });
       expect(showMoreButton).not.toHaveAttribute('data-allow-post-navigation');
-      expect(showMoreButton).toHaveAttribute('type', 'button');
-      expect(showMoreButton).toHaveTextContent('more');
-      expect(showMoreButton.parentElement).toHaveProperty('tagName', 'P');
       expect(showMoreButton.previousSibling?.textContent).toMatch(/\.\.\.\u00a0$/);
-      expect(showMoreButton).toHaveClass('cursor-pointer');
-      expect(showMoreButton).toHaveClass('text-brand');
-      expect(showMoreButton).not.toHaveClass('mt-4');
     });
 
     it('expands truncated content in place and stops event propagation on "Show more" click', () => {

--- a/src/components/molecules/PostText/PostText.test.tsx
+++ b/src/components/molecules/PostText/PostText.test.tsx
@@ -890,6 +890,24 @@ describe('PostText', () => {
       expect(screen.queryByText(/\.\.\./)).not.toBeInTheDocument();
     });
 
+    it('keeps the inline more button when character truncation ends inside a fenced code block', () => {
+      const hiddenCode = 'const hiddenMarker = true;';
+      const content = ['```typescript', generateContent(TRUNCATION_LIMIT + 100), hiddenCode, '```'].join('\n');
+      const { container } = render(<PostText content={content} />);
+
+      const codeBlock = screen.getByTestId('post-code-block');
+      const showMoreButton = screen.getByRole('button', { name: 'Show full post content' });
+      expect(codeBlock).not.toHaveTextContent('...\u00a0');
+      expect(showMoreButton.parentElement).toHaveProperty('tagName', 'P');
+      expect(showMoreButton.previousSibling?.textContent).toBe('...\u00a0');
+      expect(container.textContent).not.toContain(hiddenCode);
+
+      fireEvent.click(showMoreButton);
+
+      expect(screen.queryByRole('button', { name: 'Show full post content' })).not.toBeInTheDocument();
+      expect(container.textContent).toContain(hiddenCode);
+    });
+
     it('does not show Show more when blank markdown separators push raw lines over the line limit', () => {
       const content = ['ad', '', '', '', '', '', 'da'].join('\n');
       render(<PostText content={content} />);

--- a/src/components/molecules/PostText/PostText.test.tsx
+++ b/src/components/molecules/PostText/PostText.test.tsx
@@ -897,7 +897,7 @@ describe('PostText', () => {
 
       const codeBlock = screen.getByTestId('post-code-block');
       const showMoreButton = screen.getByRole('button', { name: 'Show full post content' });
-      expect(codeBlock).not.toHaveTextContent('...\u00a0');
+      expect(codeBlock).not.toHaveTextContent('...');
       expect(showMoreButton.parentElement).toHaveProperty('tagName', 'P');
       expect(showMoreButton.previousSibling?.textContent).toBe('...\u00a0');
       expect(container.textContent).not.toContain(hiddenCode);
@@ -906,6 +906,34 @@ describe('PostText', () => {
 
       expect(screen.queryByRole('button', { name: 'Show full post content' })).not.toBeInTheDocument();
       expect(container.textContent).toContain(hiddenCode);
+    });
+
+    it('keeps the more button when character truncation ends inside a GFM table', () => {
+      const hiddenTail = 'TABLE_HIDDEN_TAIL_MARKER';
+      const content = ['a', 'b', 'c', '| h1 | h2 |', '| --- | --- |', '| c1 | c2 |', hiddenTail].join('\n');
+      const { container } = render(<PostText content={content} />);
+
+      const showMoreButton = screen.getByRole('button', { name: 'Show full post content' });
+      expect(container.textContent).not.toContain(hiddenTail);
+
+      fireEvent.click(showMoreButton);
+
+      expect(screen.queryByRole('button', { name: 'Show full post content' })).not.toBeInTheDocument();
+      expect(container.textContent).toContain(hiddenTail);
+    });
+
+    it('keeps the more button when character truncation ends inside a raw HTML block', () => {
+      const hiddenTail = 'HTML_HIDDEN_TAIL_MARKER';
+      const content = ['a', 'b', 'c', 'd', 'e', '<div>foo</div>', '', hiddenTail].join('\n');
+      const { container } = render(<PostText content={content} />);
+
+      const showMoreButton = screen.getByRole('button', { name: 'Show full post content' });
+      expect(container.textContent).not.toContain(hiddenTail);
+
+      fireEvent.click(showMoreButton);
+
+      expect(screen.queryByRole('button', { name: 'Show full post content' })).not.toBeInTheDocument();
+      expect(container.textContent).toContain(hiddenTail);
     });
 
     it('does not show Show more when blank markdown separators push raw lines over the line limit', () => {

--- a/src/components/molecules/PostText/PostText.test.tsx.snap
+++ b/src/components/molecules/PostText/PostText.test.tsx.snap
@@ -1001,7 +1001,7 @@ exports[`PostText - Snapshots > matches snapshot for strikethrough text 1`] = `
 </div>
 `;
 
-exports[`PostText - Snapshots > matches snapshot for truncated content with Show more button 1`] = `
+exports[`PostText - Snapshots > matches snapshot for truncated content with inline more button 1`] = `
 <div
   class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
@@ -1009,15 +1009,15 @@ exports[`PostText - Snapshots > matches snapshot for truncated content with Show
 >
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse... 
+    <button
+      aria-label="Show full post content"
+      class="cursor-pointer text-brand transition-colors hover:text-brand/80"
+      data-override-defaults="true"
+      type="button"
+    >
+      more
+    </button>
   </p>
-  <button
-    aria-label="Show full post content"
-    class="mt-4 cursor-pointer text-brand transition-colors hover:text-brand/80"
-    data-override-defaults="true"
-    type="button"
-  >
-    Show more
-  </button>
 </div>
 `;
 

--- a/src/components/molecules/PostText/PostText.tsx
+++ b/src/components/molecules/PostText/PostText.tsx
@@ -11,7 +11,7 @@ import { cn } from '@/libs/utils/utils';
 import { PostMentions } from '@/organisms/PostMentions/PostMentions';
 import { PostCodeBlock } from '../PostCodeBlock/PostCodeBlock';
 import { PostHashtags } from '../PostHashtags/PostHashtags';
-import { PostTextProps, RemarkAnchorProps } from './PostText.types';
+import { PostTextProps, RemarkAnchorProps, RemarkButtonProps } from './PostText.types';
 import {
   remarkDisallowMarkdownLinks,
   remarkExtractFirstParagraph,
@@ -22,6 +22,8 @@ import {
   remarkPlaintextTables,
   truncatePostPreviewText,
 } from './PostText.utils';
+
+const INLINE_LINK_CLASSNAME = 'cursor-pointer text-brand transition-colors hover:text-brand/80';
 
 /**
  * Renders formatted text content with markdown, hashtags, mentions, and links.
@@ -112,7 +114,7 @@ export const PostText = memo(function PostText({ content, isArticle, onLinkClick
                     onLinkClick(rest.href, e);
                   }
                 }}
-                className={cn(className, 'cursor-pointer text-brand transition-colors hover:text-brand/80')}
+                className={cn(className, INLINE_LINK_CLASSNAME)}
               >
                 {children}
               </a>
@@ -148,14 +150,16 @@ export const PostText = memo(function PostText({ content, isArticle, onLinkClick
           code(props) {
             return <PostCodeBlock {...props} />;
           },
-          button(props) {
-            const { children, className, node: _node, ref: _ref, ...rest } = props;
+          button(props: RemarkButtonProps) {
+            const { children, className, 'data-type': dataType, node: _node, ref: _ref, ...rest } = props;
+
+            if (dataType !== 'show-more') return children;
 
             return (
               <Button
                 {...rest}
                 overrideDefaults
-                className={cn(className, 'cursor-pointer text-brand transition-colors hover:text-brand/80')}
+                className={cn(className, INLINE_LINK_CLASSNAME)}
                 onClick={(event) => {
                   event.stopPropagation();
                   setIsExpanded(true);

--- a/src/components/molecules/PostText/PostText.tsx
+++ b/src/components/molecules/PostText/PostText.tsx
@@ -16,6 +16,7 @@ import {
   remarkDisallowMarkdownLinks,
   remarkExtractFirstParagraph,
   remarkHashtags,
+  remarkInlineShowMore,
   remarkMentions,
   remarkPlaintextCodeblock,
   remarkPlaintextTables,
@@ -34,7 +35,7 @@ import {
  * - Hashtag parsing (#tag → clickable search link)
  * - Mention parsing (pk:... or pubky... → clickable profile link)
  * - URL detection and linking
- * - Content truncation with in-place "Show more" on non-post pages
+ * - Content truncation with an inline "more" control on non-post pages
  *
  * Memoization prevents unnecessary re-renders when TTL refreshes update IndexedDB records
  * without changes to the actual post content.
@@ -54,6 +55,7 @@ export const PostText = memo(function PostText({ content, isArticle, onLinkClick
     remarkPlaintextCodeblock,
     remarkHashtags,
     remarkMentions,
+    ...(showMoreButton ? [remarkInlineShowMore] : []),
   ];
 
   // Memoize allowed elements array to avoid recreation on every render
@@ -72,6 +74,7 @@ export const PostText = memo(function PostText({ content, isArticle, onLinkClick
       'del',
       'blockquote',
       'hr',
+      'button',
       ...(isArticle ? ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] : []),
     ],
     [isArticle],
@@ -145,6 +148,23 @@ export const PostText = memo(function PostText({ content, isArticle, onLinkClick
           code(props) {
             return <PostCodeBlock {...props} />;
           },
+          button(props) {
+            const { children, className, node: _node, ref: _ref, ...rest } = props;
+
+            return (
+              <Button
+                {...rest}
+                overrideDefaults
+                className={cn(className, 'cursor-pointer text-brand transition-colors hover:text-brand/80')}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setIsExpanded(true);
+                }}
+              >
+                {children}
+              </Button>
+            );
+          },
           h1(props) {
             const { children, className, node: _node, ref: _ref, ...rest } = props;
 
@@ -203,21 +223,6 @@ export const PostText = memo(function PostText({ content, isArticle, onLinkClick
       >
         {contentTruncated || content}
       </Markdown>
-
-      {showMoreButton && (
-        <Button
-          overrideDefaults
-          type="button"
-          aria-label="Show full post content"
-          className="mt-4 cursor-pointer text-brand transition-colors hover:text-brand/80"
-          onClick={(event) => {
-            event.stopPropagation();
-            setIsExpanded(true);
-          }}
-        >
-          Show more
-        </Button>
-      )}
     </Container>
   );
 });

--- a/src/components/molecules/PostText/PostText.types.ts
+++ b/src/components/molecules/PostText/PostText.types.ts
@@ -1,4 +1,4 @@
-import { AnchorHTMLAttributes, ClassAttributes } from 'react';
+import { AnchorHTMLAttributes, ButtonHTMLAttributes, ClassAttributes } from 'react';
 import type React from 'react';
 import { ExtraProps } from 'react-markdown';
 
@@ -11,4 +11,8 @@ export interface PostTextProps {
 
 export type RemarkAnchorProps = ClassAttributes<HTMLAnchorElement> &
   AnchorHTMLAttributes<HTMLAnchorElement> &
+  ExtraProps & { 'data-type'?: string };
+
+export type RemarkButtonProps = ClassAttributes<HTMLButtonElement> &
+  ButtonHTMLAttributes<HTMLButtonElement> &
   ExtraProps & { 'data-type'?: string };

--- a/src/components/molecules/PostText/PostText.utils.test.ts
+++ b/src/components/molecules/PostText/PostText.utils.test.ts
@@ -123,6 +123,31 @@ describe('remarkInlineShowMore', () => {
       ],
     });
   });
+
+  it('appends a fallback more paragraph when no truncated node matches', () => {
+    const htmlNode = { type: 'html', value: '<div>foo</div>...\u00a0' } as RootContent;
+    const tree = createRoot([htmlNode]);
+
+    remarkInlineShowMore()(tree);
+
+    expect(tree.children[1]).toMatchObject({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: '...\u00a0' },
+        {
+          type: 'text',
+          value: 'more',
+          data: {
+            hName: 'button',
+            hProperties: {
+              'aria-label': 'Show full post content',
+              type: 'button',
+            },
+          },
+        },
+      ],
+    });
+  });
 });
 
 describe('remarkDisallowMarkdownLinks', () => {

--- a/src/components/molecules/PostText/PostText.utils.test.ts
+++ b/src/components/molecules/PostText/PostText.utils.test.ts
@@ -8,6 +8,7 @@ import {
   remarkDisallowMarkdownLinks,
   remarkExtractFirstParagraph,
   remarkHashtags,
+  remarkInlineShowMore,
   remarkMentions,
   remarkPlaintextCodeblock,
   truncateAtWordBoundary,
@@ -74,6 +75,53 @@ describe('remarkPlaintextCodeblock', () => {
     expect(codeBlock1.lang).toBe('plaintext');
     expect(codeBlock2.lang).toBe('python');
     expect(codeBlock3.lang).toBe('plaintext');
+  });
+});
+
+describe('remarkInlineShowMore', () => {
+  it('appends the more button to a truncated paragraph', () => {
+    const paragraph = createParagraph('Truncated...\u00a0');
+    const tree = createRoot([paragraph]);
+
+    remarkInlineShowMore()(tree);
+
+    expect(paragraph.children.at(-1)).toMatchObject({
+      type: 'text',
+      value: 'more',
+      data: {
+        hName: 'button',
+        hProperties: {
+          'aria-label': 'Show full post content',
+          type: 'button',
+        },
+      },
+    });
+  });
+
+  it('moves a code-block ellipsis into a paragraph with the more button', () => {
+    const codeBlock: Code = { type: 'code', value: 'const value = true;...\u00a0', lang: 'typescript' };
+    const tree = createRoot([codeBlock]);
+
+    remarkInlineShowMore()(tree);
+
+    expect(codeBlock.value).toBe('const value = true;');
+    expect(tree.children[1]).toMatchObject({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: '...\u00a0' },
+        {
+          type: 'text',
+          value: 'more',
+          data: {
+            hName: 'button',
+            hProperties: {
+              'aria-label': 'Show full post content',
+              type: 'button',
+            },
+          },
+        },
+      ],
+    });
   });
 });
 

--- a/src/components/molecules/PostText/PostText.utils.test.ts
+++ b/src/components/molecules/PostText/PostText.utils.test.ts
@@ -79,23 +79,44 @@ describe('remarkPlaintextCodeblock', () => {
 });
 
 describe('remarkInlineShowMore', () => {
+  const showMoreButton = {
+    type: 'text',
+    value: 'more',
+    data: {
+      hName: 'button',
+      hProperties: {
+        'aria-label': 'Show full post content',
+        'data-type': 'show-more',
+        type: 'button',
+      },
+    },
+  };
+
+  const ellipsisWithButton = {
+    type: 'paragraph',
+    children: [{ type: 'text', value: '...\u00a0' }, showMoreButton],
+  };
+
   it('appends the more button to a truncated paragraph', () => {
     const paragraph = createParagraph('Truncated...\u00a0');
     const tree = createRoot([paragraph]);
 
     remarkInlineShowMore()(tree);
 
-    expect(paragraph.children.at(-1)).toMatchObject({
-      type: 'text',
-      value: 'more',
-      data: {
-        hName: 'button',
-        hProperties: {
-          'aria-label': 'Show full post content',
-          type: 'button',
-        },
-      },
-    });
+    expect(paragraph.children.at(-1)).toMatchObject(showMoreButton);
+  });
+
+  it('appends the more button to a truncated heading', () => {
+    const heading: Heading = {
+      type: 'heading',
+      depth: 1,
+      children: [{ type: 'text', value: 'Title...\u00a0' } as Text],
+    };
+    const tree = createRoot([heading]);
+
+    remarkInlineShowMore()(tree);
+
+    expect(heading.children.at(-1)).toMatchObject(showMoreButton);
   });
 
   it('moves a code-block ellipsis into a paragraph with the more button', () => {
@@ -105,48 +126,50 @@ describe('remarkInlineShowMore', () => {
     remarkInlineShowMore()(tree);
 
     expect(codeBlock.value).toBe('const value = true;');
-    expect(tree.children[1]).toMatchObject({
-      type: 'paragraph',
-      children: [
-        { type: 'text', value: '...\u00a0' },
-        {
-          type: 'text',
-          value: 'more',
-          data: {
-            hName: 'button',
-            hProperties: {
-              'aria-label': 'Show full post content',
-              type: 'button',
-            },
-          },
-        },
-      ],
-    });
+    expect(tree.children[1]).toMatchObject(ellipsisWithButton);
   });
 
-  it('appends a fallback more paragraph when no truncated node matches', () => {
+  it('removes the ellipsis from a block that cannot host the button so it is not rendered twice', () => {
     const htmlNode = { type: 'html', value: '<div>foo</div>...\u00a0' } as RootContent;
     const tree = createRoot([htmlNode]);
 
     remarkInlineShowMore()(tree);
 
-    expect(tree.children[1]).toMatchObject({
-      type: 'paragraph',
-      children: [
-        { type: 'text', value: '...\u00a0' },
-        {
-          type: 'text',
-          value: 'more',
-          data: {
-            hName: 'button',
-            hProperties: {
-              'aria-label': 'Show full post content',
-              type: 'button',
-            },
-          },
-        },
-      ],
-    });
+    expect(htmlNode).toMatchObject({ value: '<div>foo</div>' });
+    expect(tree.children[1]).toMatchObject(ellipsisWithButton);
+  });
+
+  it('places the button after a blockquote instead of inside the quoted text', () => {
+    const quoted = createParagraph('Quoted line...\u00a0');
+    const blockquote: Blockquote = { type: 'blockquote', children: [quoted] };
+    const tree = createRoot([blockquote]);
+
+    remarkInlineShowMore()(tree);
+
+    expect(getParagraphPlainText(quoted)).toBe('Quoted line');
+    expect(tree.children[1]).toMatchObject(ellipsisWithButton);
+  });
+
+  it('ignores a user-authored ellipsis in an earlier paragraph', () => {
+    const pasted = createParagraph('I pasted this...\u00a0');
+    const truncatedBlock = createParagraph('| c1 | c2 | ... |');
+    const tree = createRoot([pasted, truncatedBlock]);
+
+    remarkInlineShowMore()(tree);
+
+    expect(pasted.children).toHaveLength(1);
+    expect(truncatedBlock.children.at(-1)).toMatchObject(showMoreButton);
+  });
+
+  it('leaves an earlier code block ending with a user-authored ellipsis untouched', () => {
+    const codeBlock: Code = { type: 'code', value: 'const a = 1;...\u00a0', lang: 'js' };
+    const truncatedBlock = createParagraph('| c1 | c2 |');
+    const tree = createRoot([codeBlock, truncatedBlock]);
+
+    remarkInlineShowMore()(tree);
+
+    expect(codeBlock.value).toBe('const a = 1;...\u00a0');
+    expect(truncatedBlock.children.at(-1)).toMatchObject(showMoreButton);
   });
 });
 

--- a/src/components/molecules/PostText/PostText.utils.ts
+++ b/src/components/molecules/PostText/PostText.utils.ts
@@ -250,6 +250,31 @@ export const remarkMentions = createPatternPlugin({
   dataType: 'mention',
 });
 
+export const remarkInlineShowMore = () => (tree: Root) => {
+  const truncatedParagraphs: (Paragraph | Heading)[] = [];
+
+  visit(tree, (node) => {
+    if ((node.type === 'paragraph' || node.type === 'heading') && extractText(node).endsWith(TRUNCATION_ELLIPSIS)) {
+      truncatedParagraphs.push(node);
+    }
+  });
+
+  const truncatedParagraph = truncatedParagraphs.at(-1);
+  if (!truncatedParagraph) return;
+
+  truncatedParagraph.children.push({
+    type: 'text',
+    value: 'more',
+    data: {
+      hName: 'button',
+      hProperties: {
+        'aria-label': 'Show full post content',
+        type: 'button',
+      },
+    },
+  } as Text);
+};
+
 // Extract text safely - children from remark is typically a text node
 export const extractTextFromChildren = (children: ReactNode) =>
   typeof children === 'string'

--- a/src/components/molecules/PostText/PostText.utils.ts
+++ b/src/components/molecules/PostText/PostText.utils.ts
@@ -264,16 +264,25 @@ const createInlineShowMoreButton = (): Text =>
     },
   }) as Text;
 
-type InlineShowMoreTarget =
-  | { type: 'inline'; node: Paragraph | Heading }
-  | { type: 'code'; node: Code; index: number; parent: Parent };
+const createEllipsisParagraph = (): Paragraph => ({
+  type: 'paragraph',
+  children: [{ type: 'text', value: TRUNCATION_ELLIPSIS } as Text],
+});
+
+const createInlineShowMoreParagraph = (): Paragraph => {
+  const paragraph = createEllipsisParagraph();
+  paragraph.children.push(createInlineShowMoreButton());
+  return paragraph;
+};
 
 export const remarkInlineShowMore = () => (tree: Root) => {
-  const targets: InlineShowMoreTarget[] = [];
+  let inline: Paragraph | Heading | undefined;
+  let code: { node: Code; index: number; parent: Parent } | undefined;
 
   visit(tree, (node, index, parent) => {
     if ((node.type === 'paragraph' || node.type === 'heading') && extractText(node).endsWith(TRUNCATION_ELLIPSIS)) {
-      targets.push({ type: 'inline', node });
+      inline = node;
+      code = undefined;
     }
 
     if (
@@ -282,29 +291,23 @@ export const remarkInlineShowMore = () => (tree: Root) => {
       typeof index === 'number' &&
       parent
     ) {
-      targets.push({ type: 'code', node, index, parent });
+      inline = undefined;
+      code = { node, index, parent };
     }
   });
 
-  const target = targets.at(-1);
-  if (!target) return;
-
-  if (target.type === 'inline') {
-    target.node.children.push(createInlineShowMoreButton());
+  if (inline) {
+    inline.children.push(createInlineShowMoreButton());
     return;
   }
 
-  target.node.value = target.node.value.slice(0, -TRUNCATION_ELLIPSIS.length);
-  target.parent.children.splice(target.index + 1, 0, {
-    type: 'paragraph',
-    children: [
-      {
-        type: 'text',
-        value: TRUNCATION_ELLIPSIS,
-      } as Text,
-      createInlineShowMoreButton(),
-    ],
-  } as Paragraph);
+  if (code) {
+    code.node.value = code.node.value.slice(0, -TRUNCATION_ELLIPSIS.length);
+    code.parent.children.splice(code.index + 1, 0, createInlineShowMoreParagraph());
+    return;
+  }
+
+  tree.children.push(createInlineShowMoreParagraph());
 };
 
 // Extract text safely - children from remark is typically a text node
@@ -438,11 +441,6 @@ const appendEllipsisToListItem = (listItem: ListItem): void => {
     children: [{ type: 'text', value: TRUNCATION_ELLIPSIS } as Text],
   } as Paragraph);
 };
-
-const createEllipsisParagraph = (): Paragraph => ({
-  type: 'paragraph',
-  children: [{ type: 'text', value: TRUNCATION_ELLIPSIS } as Text],
-});
 
 const appendEllipsisToPreviewNode = (node: unknown): boolean => {
   if (!node || typeof node !== 'object') return false;

--- a/src/components/molecules/PostText/PostText.utils.ts
+++ b/src/components/molecules/PostText/PostText.utils.ts
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 import type {
   Blockquote,
-  Code,
   Heading,
   Link,
   List,
@@ -259,6 +258,7 @@ const createInlineShowMoreButton = (): Text =>
       hName: 'button',
       hProperties: {
         'aria-label': 'Show full post content',
+        'data-type': 'show-more',
         type: 'button',
       },
     },
@@ -275,38 +275,34 @@ const createInlineShowMoreParagraph = (): Paragraph => {
   return paragraph;
 };
 
+// Blocks that cannot host the inline button get the ellipsis paragraph appended after them instead.
+// Their own trailing ellipsis is removed first so the preview does not render two of them.
+const stripTrailingEllipsis = (node: RootContent | undefined): void => {
+  if (!node) return;
+
+  if ('value' in node && typeof node.value === 'string') {
+    if (node.value.endsWith(TRUNCATION_ELLIPSIS)) {
+      node.value = node.value.slice(0, -TRUNCATION_ELLIPSIS.length);
+    }
+
+    return;
+  }
+
+  if ('children' in node) stripTrailingEllipsis(node.children.at(-1));
+};
+
+// truncatePostPreviewText appends the ellipsis to the very end of the preview text, so the cut is
+// always in the last top-level block. Attaching there instead of searching the tree for the
+// ellipsis keeps a user-authored ellipsis from stealing the button or losing its own characters.
 export const remarkInlineShowMore = () => (tree: Root) => {
-  let inline: Paragraph | Heading | undefined;
-  let code: { node: Code; index: number; parent: Parent } | undefined;
+  const lastBlock = tree.children.at(-1);
 
-  visit(tree, (node, index, parent) => {
-    if ((node.type === 'paragraph' || node.type === 'heading') && extractText(node).endsWith(TRUNCATION_ELLIPSIS)) {
-      inline = node;
-      code = undefined;
-    }
-
-    if (
-      node.type === 'code' &&
-      extractText(node).endsWith(TRUNCATION_ELLIPSIS) &&
-      typeof index === 'number' &&
-      parent
-    ) {
-      inline = undefined;
-      code = { node, index, parent };
-    }
-  });
-
-  if (inline) {
-    inline.children.push(createInlineShowMoreButton());
+  if (lastBlock?.type === 'paragraph' || lastBlock?.type === 'heading') {
+    lastBlock.children.push(createInlineShowMoreButton());
     return;
   }
 
-  if (code) {
-    code.node.value = code.node.value.slice(0, -TRUNCATION_ELLIPSIS.length);
-    code.parent.children.splice(code.index + 1, 0, createInlineShowMoreParagraph());
-    return;
-  }
-
+  stripTrailingEllipsis(lastBlock);
   tree.children.push(createInlineShowMoreParagraph());
 };
 

--- a/src/components/molecules/PostText/PostText.utils.ts
+++ b/src/components/molecules/PostText/PostText.utils.ts
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import type {
   Blockquote,
+  Code,
   Heading,
   Link,
   List,
@@ -250,19 +251,8 @@ export const remarkMentions = createPatternPlugin({
   dataType: 'mention',
 });
 
-export const remarkInlineShowMore = () => (tree: Root) => {
-  const truncatedParagraphs: (Paragraph | Heading)[] = [];
-
-  visit(tree, (node) => {
-    if ((node.type === 'paragraph' || node.type === 'heading') && extractText(node).endsWith(TRUNCATION_ELLIPSIS)) {
-      truncatedParagraphs.push(node);
-    }
-  });
-
-  const truncatedParagraph = truncatedParagraphs.at(-1);
-  if (!truncatedParagraph) return;
-
-  truncatedParagraph.children.push({
+const createInlineShowMoreButton = (): Text =>
+  ({
     type: 'text',
     value: 'more',
     data: {
@@ -272,7 +262,49 @@ export const remarkInlineShowMore = () => (tree: Root) => {
         type: 'button',
       },
     },
-  } as Text);
+  }) as Text;
+
+type InlineShowMoreTarget =
+  | { type: 'inline'; node: Paragraph | Heading }
+  | { type: 'code'; node: Code; index: number; parent: Parent };
+
+export const remarkInlineShowMore = () => (tree: Root) => {
+  const targets: InlineShowMoreTarget[] = [];
+
+  visit(tree, (node, index, parent) => {
+    if ((node.type === 'paragraph' || node.type === 'heading') && extractText(node).endsWith(TRUNCATION_ELLIPSIS)) {
+      targets.push({ type: 'inline', node });
+    }
+
+    if (
+      node.type === 'code' &&
+      extractText(node).endsWith(TRUNCATION_ELLIPSIS) &&
+      typeof index === 'number' &&
+      parent
+    ) {
+      targets.push({ type: 'code', node, index, parent });
+    }
+  });
+
+  const target = targets.at(-1);
+  if (!target) return;
+
+  if (target.type === 'inline') {
+    target.node.children.push(createInlineShowMoreButton());
+    return;
+  }
+
+  target.node.value = target.node.value.slice(0, -TRUNCATION_ELLIPSIS.length);
+  target.parent.children.splice(target.index + 1, 0, {
+    type: 'paragraph',
+    children: [
+      {
+        type: 'text',
+        value: TRUNCATION_ELLIPSIS,
+      } as Text,
+      createInlineShowMoreButton(),
+    ],
+  } as Paragraph);
 };
 
 // Extract text safely - children from remark is typically a text node

--- a/src/components/organisms/PostContentBase/PostContentBase.test.tsx.snap
+++ b/src/components/organisms/PostContentBase/PostContentBase.test.tsx.snap
@@ -98,15 +98,15 @@ exports[`PostContentBase - Snapshots > matches snapshot with very long content 1
   >
     <p>
       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA... 
+      <button
+        aria-label="Show full post content"
+        class="cursor-pointer text-brand transition-colors hover:text-brand/80"
+        data-testid="button"
+        type="button"
+      >
+        more
+      </button>
     </p>
-    <button
-      aria-label="Show full post content"
-      class="mt-4 cursor-pointer text-brand transition-colors hover:text-brand/80"
-      data-testid="button"
-      type="button"
-    >
-      Show more
-    </button>
   </div>
   <div
     data-testid="post-attachments"


### PR DESCRIPTION
## Summary

- render the truncated-post expansion control inline immediately after the ellipsis
- shorten the visible label from Show more to more to remove extra vertical spacing
- preserve the accessible label, in-place expansion, and event handling
- update PostText and PostContentBase regression snapshots

## Why
The current “Show more” control renders on a separate line, after a break line, adding unnecessary vertical space to truncated posts. Placing a shorter “more” link directly after the ellipsis keeps posts compact, makes the continuation feel connected to the truncated text, and preserves the existing expansion behavior and accessibility.

## Before
<img width="827" height="238" alt="image" src="https://github.com/user-attachments/assets/ea936fb3-f495-4ff8-912b-e845affe9779" />

## After
<img width="777" height="206" alt="image" src="https://github.com/user-attachments/assets/485a79e0-312b-4e45-99e9-43ab8ed985e9" />


## Testing

- npm test -- src/components/molecules/PostText/PostText.test.tsx src/components/molecules/PostText/PostText.utils.test.ts src/components/organisms/PostContentBase/PostContentBase.test.tsx
- npx eslint src/components/molecules/PostText/PostText.tsx src/components/molecules/PostText/PostText.utils.ts src/components/molecules/PostText/PostText.test.tsx
- npx prettier --check src/components/molecules/PostText/PostText.tsx src/components/molecules/PostText/PostText.utils.ts src/components/molecules/PostText/PostText.test.tsx
- npm run typecheck
