### PR TITLE
fix(ui): truncate long profile usernames

### DIFF
--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
@@ -164,6 +164,24 @@ describe('ProfilePageHeader', () => {
     expect(actions).not.toHaveClass('lg:mt-3');
   });
 
+  it('constrains long names so they truncate before the status emoji', () => {
+    const props = {
+      ...mockProps,
+      profile: { ...mockProps.profile, name: `Bobi${'W'.repeat(80)}` },
+    };
+
+    render(<ProfilePageHeader {...props} />);
+
+    const name = screen.getByRole('heading', { name: props.profile.name });
+    const nameRow = name.parentElement;
+    const statusEmoji = screen.getByRole('button', { name: 'Vacationing status' });
+
+    expect(nameRow).toHaveClass('w-full', 'min-w-0');
+    expect(name).toHaveClass('min-w-0', 'truncate');
+    expect(name.nextElementSibling).toBe(statusEmoji);
+    expect(statusEmoji).toHaveClass('shrink-0');
+  });
+
   it('renders formatted public key', () => {
     render(<ProfilePageHeader {...mockProps} />);
 

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`ProfilePageHeader - Mobile Snapshots > matches snapshot on mobile viewp
       data-testid="container"
     >
       <div
-        class="max-width-profile-page-header flex w-fit min-w-0 items-center gap-2 sm:max-w-xl lg:max-w-full lg:gap-3"
+        class="max-width-profile-page-header flex w-full min-w-0 items-center gap-2 sm:max-w-xl lg:max-w-full lg:gap-3"
         data-testid="container"
       >
         <h1
@@ -339,7 +339,7 @@ exports[`ProfilePageHeader - Snapshots > matches snapshot 1`] = `
       data-testid="container"
     >
       <div
-        class="max-width-profile-page-header flex w-fit min-w-0 items-center gap-2 sm:max-w-xl lg:max-w-full lg:gap-3"
+        class="max-width-profile-page-header flex w-full min-w-0 items-center gap-2 sm:max-w-xl lg:max-w-full lg:gap-3"
         data-testid="container"
       >
         <h1

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
@@ -130,7 +130,7 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
         >
           <Container
             overrideDefaults
-            className="max-width-profile-page-header flex w-fit min-w-0 items-center gap-2 sm:max-w-xl lg:max-w-full lg:gap-3"
+            className="max-width-profile-page-header flex w-full min-w-0 items-center gap-2 sm:max-w-xl lg:max-w-full lg:gap-3"
           >
             <Typography
               data-cy="profile-username-header"

--- a/src/test/vrt/profile/Profile.vrt.test.tsx
+++ b/src/test/vrt/profile/Profile.vrt.test.tsx
@@ -878,6 +878,24 @@ describe('Own profile — posts — visual regression', () => {
     await expect.element(screen.getByText('9 more replies')).toBeVisible();
     await expect(screen.getByTestId(VRT_ROOT_TESTID)).toMatchScreenshot('own-profile-posts-mobile');
   });
+
+  it('truncates a long profile name before the status emoji at desktop viewport', async () => {
+    const screen = await renderOwnProfileTab('/profile/posts', <ProfilePostsPage />, VRT_VIEWPORT_DESKTOP);
+    await expect.element(screen.getByRole('feed').first()).toBeVisible();
+
+    const header = screen.getByTestId('profile-page-header');
+    const name = header.element().querySelector('[data-cy="profile-username-header"]');
+    const statusEmoji = header.getByRole('button', { name: 'Vacationing status' }).element();
+
+    expect(name).toBeInstanceOf(HTMLElement);
+    if (!(name instanceof HTMLElement)) return;
+
+    // Exercise the layout without changing the shared profile fixture and every profile screenshot baseline.
+    name.textContent = `Bobi${'W'.repeat(80)}`;
+
+    expect(name.scrollWidth).toBeGreaterThan(name.clientWidth);
+    expect(name.getBoundingClientRect().right).toBeLessThan(statusEmoji.getBoundingClientRect().left);
+  });
 });
 
 describe('Own profile — replies — visual regression', () => {


### PR DESCRIPTION
## Context

PR #[2380](https://github.com/pubky/pubky-app/pull/2380#issuecomment-5399846415) moved the profile status emoji beside the username, but the new shrink-to-fit row allowed long usernames to grow beyond the profile content column instead of truncating.

## Summary
- constrain the profile name/status row so long usernames ellipsize
- keep the status emoji visible beside the truncated name
- add unit, snapshot, and real-browser layout regression coverage

## Testing
- [x] ProfilePageHeader unit suite (30 tests)
- [x] ESLint on changed source and test files
- [x] Prettier on changed source and test files
- [x] VRT baseline integrity check
- [x] staged diff check