### PR TITLE
fix(ui):Narrow custom feed creation and edit dialogs

### DIFF
--- a/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx
+++ b/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx
@@ -597,14 +597,14 @@ describe('CustomFeedDialog', () => {
     expect(actions).toEqual([screen.getByTestId('delete-feed-button'), screen.getByTestId('save-feed-button')]);
   });
 
-  it('applies w-3xl class to dialog content', () => {
+  it('limits the dialog content to the xl width preset', () => {
     render(
       <CustomFeedDialog mode="create">
         <button>Create Feed</button>
       </CustomFeedDialog>,
     );
 
-    expect(screen.getByTestId('custom-feed-dialog-content')).toHaveClass('w-3xl');
+    expect(screen.getByTestId('custom-feed-dialog-content')).toHaveClass('w-xl');
   });
 
   // -- Trigger disabled state --

--- a/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx.snap
+++ b/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for create mode default
     </button>
   </div>
   <div
-    class="w-3xl"
+    class="w-xl"
     data-testid="custom-feed-dialog-content"
   >
     <div
@@ -992,7 +992,7 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for create mode with di
     </span>
   </div>
   <div
-    class="w-3xl"
+    class="w-xl"
     data-testid="custom-feed-dialog-content"
   >
     <div
@@ -1968,7 +1968,7 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for edit mode with cust
     </button>
   </div>
   <div
-    class="w-3xl"
+    class="w-xl"
     data-testid="custom-feed-dialog-content"
   >
     <div
@@ -3018,7 +3018,7 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for edit mode with null
     </button>
   </div>
   <div
-    class="w-3xl"
+    class="w-xl"
     data-testid="custom-feed-dialog-content"
   >
     <div

--- a/src/components/organisms/CustomFeedDialog/CustomFeedDialog.tsx
+++ b/src/components/organisms/CustomFeedDialog/CustomFeedDialog.tsx
@@ -290,7 +290,7 @@ export const CustomFeedDialog = (props: CustomFeedDialogProps) => {
           }
         }}
         onCloseAutoFocus={(e) => e.preventDefault()}
-        className="w-3xl"
+        className="w-xl"
         data-testid="custom-feed-dialog-content"
       >
         <DialogHeader>

--- a/src/components/organisms/IconPickerDialog/IconPickerDialog.test.tsx
+++ b/src/components/organisms/IconPickerDialog/IconPickerDialog.test.tsx
@@ -47,6 +47,13 @@ describe('IconPickerDialog', () => {
     await waitForResolvedIcons(TEST_ICONS);
   });
 
+  it('uses the lg width preset with a ten-column desktop grid', () => {
+    render(<IconPickerDialog open onSelect={() => {}} icons={TEST_ICONS} />);
+
+    expect(screen.getByTestId('icon-picker-dialog-content')).toHaveClass('w-lg', 'sm:max-w-lg');
+    expect(screen.getByTestId('icon-picker-grid')).toHaveClass('grid-cols-6', 'sm:grid-cols-10');
+  });
+
   it('announces the result count to assistive tech', () => {
     render(<IconPickerDialog open onSelect={() => {}} icons={TEST_ICONS} />);
 

--- a/src/components/organisms/IconPickerDialog/IconPickerDialog.test.tsx.snap
+++ b/src/components/organisms/IconPickerDialog/IconPickerDialog.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`IconPickerDialog - Snapshots > matches snapshot for the empty state 1`]
   >
     <div
       aria-labelledby="radix-normalized"
-      class="relative z-50 duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] border bg-background shadow-lg sm:rounded-xl sm:rounded-b-lg rounded-t-lg border-b-0 sm:border-b flex h-110 w-145 max-w-[calc(100vw-2rem)] flex-col gap-6 overflow-hidden p-6 sm:max-w-145 sm:p-8"
+      class="relative z-50 duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] border bg-background shadow-lg sm:rounded-xl sm:rounded-b-lg rounded-t-lg border-b-0 sm:border-b flex h-110 w-lg max-w-[calc(100vw-2rem)] flex-col gap-6 overflow-hidden p-6 sm:max-w-lg sm:p-8"
       data-cy="dialog-content"
       data-slot="dialog-content"
       data-state="open"
@@ -165,7 +165,7 @@ exports[`IconPickerDialog - Snapshots > matches snapshot for the icon grid 1`] =
   >
     <div
       aria-labelledby="radix-normalized"
-      class="relative z-50 duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] border bg-background shadow-lg sm:rounded-xl sm:rounded-b-lg rounded-t-lg border-b-0 sm:border-b flex h-110 w-145 max-w-[calc(100vw-2rem)] flex-col gap-6 overflow-hidden p-6 sm:max-w-145 sm:p-8"
+      class="relative z-50 duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] border bg-background shadow-lg sm:rounded-xl sm:rounded-b-lg rounded-t-lg border-b-0 sm:border-b flex h-110 w-lg max-w-[calc(100vw-2rem)] flex-col gap-6 overflow-hidden p-6 sm:max-w-lg sm:p-8"
       data-cy="dialog-content"
       data-slot="dialog-content"
       data-state="open"
@@ -222,7 +222,7 @@ exports[`IconPickerDialog - Snapshots > matches snapshot for the icon grid 1`] =
         data-testid="icon-picker-scroll-area"
       >
         <div
-          class="grid grid-cols-6 gap-x-2 gap-y-4 sm:grid-cols-11"
+          class="grid grid-cols-6 gap-x-2 gap-y-4 sm:grid-cols-10"
           data-testid="icon-picker-grid"
         >
           <button

--- a/src/components/organisms/IconPickerDialog/IconPickerDialog.tsx
+++ b/src/components/organisms/IconPickerDialog/IconPickerDialog.tsx
@@ -182,7 +182,7 @@ export function IconPickerDialog({
       {children && <DialogTrigger asChild>{children}</DialogTrigger>}
 
       <DialogContent
-        className="flex h-110 w-145 max-w-[calc(100vw-2rem)] flex-col gap-6 overflow-hidden p-6 sm:max-w-145 sm:p-8"
+        className="flex h-110 w-lg max-w-[calc(100vw-2rem)] flex-col gap-6 overflow-hidden p-6 sm:max-w-lg sm:p-8"
         data-testid="icon-picker-dialog-content"
         onClick={(event) => event.stopPropagation()}
       >
@@ -246,7 +246,7 @@ export function IconPickerDialog({
             <>
               <Container
                 overrideDefaults
-                className="grid grid-cols-6 gap-x-2 gap-y-4 sm:grid-cols-11"
+                className="grid grid-cols-6 gap-x-2 gap-y-4 sm:grid-cols-10"
                 data-testid="icon-picker-grid"
               >
                 {visibleIcons.map(({ name: iconName }) => {


### PR DESCRIPTION
## Summary

- Reduce the shared feed creation and editing dialog from `w-3xl` (768px) to Tailwind’s `w-xl` preset (576px).
- Replace the icon picker’s custom 580px width with Tailwind’s smaller `w-lg` preset (512px).
- Adjust the desktop icon grid from 11 to 10 columns to preserve icon sizing and spacing at the narrower width.
- Keep the existing responsive viewport constraints and six-column mobile grid.
- Update focused assertions and snapshots for both dialogs.

## Why

Both dialogs present compact, focused controls that did not benefit from their previous width. The additional horizontal space made the forms feel visually dispersed, increased eye travel, and weakened the relationship between their labels and controls.

The narrower widths create a clearer hierarchy while preserving enough room for every field and action. Using standard Tailwind presets also communicates the intended sizing more clearly than an arbitrary custom width and keeps the implementation aligned with the design system.

The icon grid is reduced to 10 desktop columns so its fixed-size buttons retain their existing gaps without compression or horizontal overflow. Mobile behavior remains unchanged, and the shared feed dialog continues to apply the same sizing consistently to both creation and editing.


## Testing

- `npm test -- src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx` — 72 tests passed
- ESLint passed for the component and focused test
- `git diff --cached --check` passed

## Before
<img width="821" height="733" alt="image" src="https://github.com/user-attachments/assets/91d33cc3-bfa1-486a-8891-f3d17309b6e9" />

## After
<img width="828" height="727" alt="image" src="https://github.com/user-attachments/assets/8031f6bf-b8b3-43b4-aa82-7ac647a68a42" />

<img width="617" height="643" alt="image" src="https://github.com/user-attachments/assets/98f38c5f-f228-414c-96ec-e3b18b8d5eb7" />

