### PR TITLE
fix(ui): prevent premature feed title truncation

### DIFF
--- a/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx
@@ -403,8 +403,25 @@ describe('FeedNavigation', () => {
     expect(inactiveLabel).toHaveClass('hidden', 'lg:inline');
 
     // The active tab hugs its content on mobile; inactive tabs share the row.
-    expect(getLink('/feed/feed-active')?.parentElement).toHaveClass('flex-none', 'lg:flex-1');
+    expect(getLink('/feed/feed-active')?.parentElement).toHaveClass('flex-none', 'lg:flex-auto');
     expect(getLink('/feed/feed-other')?.parentElement).toHaveClass('min-w-12', 'flex-1');
+  });
+
+  it('gives desktop tabs content-aware flex bases before truncating feed names', () => {
+    mockCustomFeeds = [
+      createMockFeed({ id: 'feed-short', name: 'K' }),
+      createMockFeed({ id: 'feed-long', name: 'New custom feed with a longer title' }),
+    ];
+
+    render(<FeedNavigation />);
+
+    const shortTab = getLink('/feed/feed-short')?.parentElement;
+    const longTab = getLink('/feed/feed-long')?.parentElement;
+
+    expect(shortTab).toHaveClass('lg:flex-auto');
+    expect(longTab).toHaveClass('lg:flex-auto');
+    expect(shortTab).not.toHaveClass('lg:flex-1');
+    expect(longTab).not.toHaveClass('lg:flex-1');
   });
 
   // ── Edit dialog for custom feeds ────────────────────────────────────────
@@ -593,7 +610,7 @@ describe('FeedNavigation', () => {
     render(<FeedNavigation />);
 
     const homeLink = getLink('/home');
-    expect(homeLink).toHaveClass('min-h-12', 'lg:min-w-40', 'lg:flex-1');
+    expect(homeLink).toHaveClass('min-h-12', 'lg:min-w-40', 'lg:flex-auto');
     // The reach tab keeps the shared active padding.
     expect(homeLink).toHaveClass('px-8');
 

--- a/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx.snap
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feed active (
   >
     <a
       aria-label="All"
-      class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 px-2 lg:px-8 border-border text-muted-foreground hover:text-white"
+      class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 lg:flex-auto px-2 lg:px-8 border-border text-muted-foreground hover:text-white"
       data-override-defaults="true"
       data-testid="link"
       href="/home"
@@ -56,7 +56,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feed active (
       </span>
     </a>
     <div
-      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 max-w-[60%] flex-none lg:max-w-none lg:flex-1 border-white"
+      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 max-w-[60%] flex-none lg:max-w-none lg:flex-auto border-white"
       data-testid="container"
     >
       <a
@@ -125,7 +125,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feed active (
     >
       <button
         aria-label="Create feed"
-        class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 px-2 lg:px-8 cursor-pointer border-border text-muted-foreground hover:text-white"
+        class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 lg:flex-auto px-2 lg:px-8 cursor-pointer border-border text-muted-foreground hover:text-white"
         data-override-defaults="true"
         data-testid="button"
       >
@@ -179,7 +179,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Hom
     <a
       aria-current="page"
       aria-label="All"
-      class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 max-w-[60%] flex-none lg:max-w-none lg:flex-1 px-8 border-white text-white"
+      class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 max-w-[60%] flex-none lg:max-w-none lg:flex-auto px-8 border-white text-white"
       data-override-defaults="true"
       data-testid="link"
       href="/home"
@@ -224,7 +224,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Hom
       </span>
     </a>
     <div
-      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 border-border"
+      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 lg:flex-auto border-border"
       data-testid="container"
     >
       <a
@@ -288,7 +288,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Hom
       </button>
     </div>
     <div
-      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 border-border"
+      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 lg:flex-auto border-border"
       data-testid="container"
     >
       <a
@@ -356,7 +356,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Hom
     >
       <button
         aria-label="Create feed"
-        class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 px-2 lg:px-8 cursor-pointer border-border text-muted-foreground hover:text-white"
+        class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 lg:flex-auto px-2 lg:px-8 cursor-pointer border-border text-muted-foreground hover:text-white"
         data-override-defaults="true"
         data-testid="button"
       >
@@ -409,7 +409,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
   >
     <a
       aria-label="All"
-      class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 px-2 lg:px-8 border-border text-muted-foreground hover:text-white"
+      class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 lg:flex-auto px-2 lg:px-8 border-border text-muted-foreground hover:text-white"
       data-override-defaults="true"
       data-testid="link"
       href="/home"
@@ -454,7 +454,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
       </span>
     </a>
     <div
-      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 border-border"
+      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 lg:flex-auto border-border"
       data-testid="container"
     >
       <a
@@ -518,7 +518,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
       </button>
     </div>
     <div
-      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 max-w-[60%] flex-none lg:max-w-none lg:flex-1 border-white"
+      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 max-w-[60%] flex-none lg:max-w-none lg:flex-auto border-white"
       data-testid="container"
     >
       <a
@@ -583,7 +583,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
       </button>
     </div>
     <div
-      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 border-border"
+      class="group relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 lg:flex-auto border-border"
       data-testid="container"
     >
       <a
@@ -651,7 +651,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
     >
       <button
         aria-label="Create feed"
-        class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 px-2 lg:px-8 cursor-pointer border-border text-muted-foreground hover:text-white"
+        class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 lg:flex-auto px-2 lg:px-8 cursor-pointer border-border text-muted-foreground hover:text-white"
         data-override-defaults="true"
         data-testid="button"
       >
@@ -705,7 +705,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with no custom feeds and 
     <a
       aria-current="page"
       aria-label="All"
-      class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 max-w-[60%] flex-none lg:max-w-none lg:flex-1 px-8 border-white text-white"
+      class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 max-w-[60%] flex-none lg:max-w-none lg:flex-auto px-8 border-white text-white"
       data-override-defaults="true"
       data-testid="link"
       href="/home"
@@ -754,7 +754,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with no custom feeds and 
     >
       <button
         aria-label="Create feed"
-        class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 px-2 lg:px-8 cursor-pointer border-border text-muted-foreground hover:text-white"
+        class="relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40 min-w-12 flex-1 lg:flex-auto px-2 lg:px-8 cursor-pointer border-border text-muted-foreground hover:text-white"
         data-override-defaults="true"
         data-testid="button"
       >

--- a/src/components/organisms/FeedNavigation/FeedNavigation.tsx
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.tsx
@@ -24,13 +24,14 @@ import { CustomFeedDialog } from '../CustomFeedDialog/CustomFeedDialog';
 
 // Below lg the strip is a sticky tab bar under the compact mobile header:
 // the selected tab shows icon + label, the rest collapse to icon-only cells.
-// At lg+ every tab is icon + label and shares the row evenly.
+// At lg+ every tab is icon + label. Content-aware flex bases let a longer
+// title use space that a shorter sibling does not need before truncating.
 const FEED_TAB_CLASS = 'relative flex min-h-12 items-center justify-center gap-2 border-b py-1.5 lg:min-w-40';
 // Below lg the active tab hugs its label, but a feed name has no length limit
 // (specs does not cap it), so cap the tab or one long name pushes every other
 // tab off-screen; the label's `truncate` then does its job.
-const FEED_TAB_ACTIVE_WIDTH_CLASS = 'max-w-[60%] flex-none lg:max-w-none lg:flex-1';
-const FEED_TAB_INACTIVE_WIDTH_CLASS = 'min-w-12 flex-1';
+const FEED_TAB_ACTIVE_WIDTH_CLASS = 'max-w-[60%] flex-none lg:max-w-none lg:flex-auto';
+const FEED_TAB_INACTIVE_WIDTH_CLASS = 'min-w-12 flex-1 lg:flex-auto';
 // Symmetric horizontal padding keeps every label centered; the active padding
 // also reserves the zone the edit pencil overlays on custom feed tabs.
 const FEED_TAB_ACTIVE_PADDING_CLASS = 'px-8';


### PR DESCRIPTION
## Summary

- Size desktop feed tabs from their content before distributing remaining space.
- Preserve the existing mobile widths, minimum widths, overflow scrolling, and final truncation behavior.
- Add regression coverage for adjacent short and long feed titles and update snapshots.

## Why

Desktop feed tabs used `flex: 1 1 0%`, which assigned equal widths regardless of label length. A longer feed name could therefore be ellipsized while adjacent short tabs still contained unused space. That makes the truncation misleading: the row has capacity, but the allocation prevents the title from using it.

Using `flex-auto` at the desktop breakpoint bases each tab on its intrinsic content before sharing the remaining space. Short labels take only what they need, longer labels can use the released space, and genuinely constrained rows still retain the existing minimum widths, horizontal overflow, and text truncation. Mobile behavior remains unchanged.

## Before
<img width="1146" height="78" alt="image" src="https://github.com/user-attachments/assets/398b2c29-52db-41bd-970e-86eae5726f9d" />

## After
<img width="1622" height="164" alt="image" src="https://github.com/user-attachments/assets/c5be92a0-bd9a-4aa5-89ff-f3daade83dba" />


## Validation

- 38 focused FeedNavigation tests passed
- TypeScript passed
- ESLint passed for the changed source and test
- Manual desktop browser QA matched the adjacent short/long-title reference

