### PR TITLE
fix: change Create Feed dialog's name title and placeholder

### DIFF
--- a/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx
+++ b/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx
@@ -446,7 +446,7 @@ describe('CustomFeedDialog', () => {
 
     const input = screen.getByTestId('feed-name-input');
     expect(input).toBeInTheDocument();
-    expect(input).toHaveAttribute('placeholder', 'Not your keys...');
+    expect(input).toHaveAttribute('placeholder', 'Name your feed');
   });
 
   it('renders the generic icon picker with the default feed icon', () => {

--- a/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx.snap
+++ b/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx.snap
@@ -34,12 +34,12 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for create mode default
         class="text-xs tracking-wide text-muted-foreground uppercase"
         data-testid="label"
       >
-        Feed Name
+        Feed Title
       </label>
       <input
         class="h-14 border-dashed"
         data-testid="feed-name-input"
-        placeholder="Not your keys..."
+        placeholder="Name your feed"
         required=""
         value=""
       />
@@ -1012,12 +1012,12 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for create mode with di
         class="text-xs tracking-wide text-muted-foreground uppercase"
         data-testid="label"
       >
-        Feed Name
+        Feed Title
       </label>
       <input
         class="h-14 border-dashed"
         data-testid="feed-name-input"
-        placeholder="Not your keys..."
+        placeholder="Name your feed"
         required=""
         value=""
       />
@@ -1988,12 +1988,12 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for edit mode with cust
         class="text-xs tracking-wide text-muted-foreground uppercase"
         data-testid="label"
       >
-        Feed Name
+        Feed Title
       </label>
       <input
         class="h-14 border-dashed"
         data-testid="feed-name-input"
-        placeholder="Not your keys..."
+        placeholder="Name your feed"
         required=""
         value="Bitcoin News"
       />
@@ -3038,12 +3038,12 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for edit mode with null
         class="text-xs tracking-wide text-muted-foreground uppercase"
         data-testid="label"
       >
-        Feed Name
+        Feed Title
       </label>
       <input
         class="h-14 border-dashed"
         data-testid="feed-name-input"
-        placeholder="Not your keys..."
+        placeholder="Name your feed"
         required=""
         value="Bitcoin News"
       />

--- a/src/components/organisms/CustomFeedDialog/CustomFeedDialog.tsx
+++ b/src/components/organisms/CustomFeedDialog/CustomFeedDialog.tsx
@@ -298,7 +298,7 @@ export const CustomFeedDialog = (props: CustomFeedDialogProps) => {
         </DialogHeader>
 
         <Container className="gap-y-2">
-          <Label className="text-xs tracking-wide text-muted-foreground uppercase">{'Feed Name'}</Label>
+          <Label className="text-xs tracking-wide text-muted-foreground uppercase">{'Feed Title'}</Label>
 
           <Controller
             name={CUSTOM_FEED_FORM_FIELDS.NAME}
@@ -306,7 +306,7 @@ export const CustomFeedDialog = (props: CustomFeedDialogProps) => {
             render={({ field }) => (
               <Input
                 required
-                placeholder={'Not your keys...'}
+                placeholder={'Name your feed'}
                 value={field.value}
                 onChange={field.onChange}
                 onBlur={field.onBlur}


### PR DESCRIPTION
Changed "FEED NAME" to "FEED TITLE" and "Not your keys..." to "Name your feed".

<img width="618" height="358" alt="Screenshot 2026-08-26 at 17 01 58" src="https://github.com/user-attachments/assets/f316656b-c15d-4e58-b118-64a672a7d40a" />
