### PR TITLE
fix(ui): make profile name descender fix work in Safari

### DIFF
--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
@@ -148,11 +148,10 @@ describe('ProfilePageHeader', () => {
     expect(screen.getByText('Satoshi Nakamoto')).toHaveClass(
       'leading-8',
       'lg:leading-none',
-      'overflow-x-clip',
-      'overflow-y-clip',
-      'text-ellipsis',
-      'whitespace-nowrap',
-      '[overflow-clip-margin:0.15em]',
+      'truncate',
+      // Descender room that Safari honors too (it lacks overflow-clip-margin support)
+      'pb-[0.15em]',
+      '-mb-[0.15em]',
     );
     expect(
       screen.getByText('Authored the Bitcoin white paper, developed Bitcoin, mined first block, disappeared.'),
@@ -185,7 +184,7 @@ describe('ProfilePageHeader', () => {
     const statusEmoji = screen.getByRole('button', { name: 'Vacationing status' });
 
     expect(nameRow).toHaveClass('w-full', 'min-w-0');
-    expect(name).toHaveClass('min-w-0', 'overflow-x-clip', 'text-ellipsis', 'whitespace-nowrap');
+    expect(name).toHaveClass('min-w-0', 'truncate');
     expect(name.nextElementSibling).toBe(statusEmoji);
     expect(statusEmoji).toHaveClass('shrink-0');
   });

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`ProfilePageHeader - Mobile Snapshots > matches snapshot on mobile viewp
         data-testid="container"
       >
         <h1
-          class="text-2xl font-bold min-w-0 overflow-x-clip overflow-y-clip leading-8 text-ellipsis whitespace-nowrap text-white [overflow-clip-margin:0.15em] lg:text-6xl lg:leading-none"
+          class="text-2xl font-bold -mb-[0.15em] min-w-0 truncate pb-[0.15em] leading-8 text-white lg:text-6xl lg:leading-none"
           data-cy="profile-username-header"
           data-testid="typography"
         >
@@ -343,7 +343,7 @@ exports[`ProfilePageHeader - Snapshots > matches snapshot 1`] = `
         data-testid="container"
       >
         <h1
-          class="text-2xl font-bold min-w-0 overflow-x-clip overflow-y-clip leading-8 text-ellipsis whitespace-nowrap text-white [overflow-clip-margin:0.15em] lg:text-6xl lg:leading-none"
+          class="text-2xl font-bold -mb-[0.15em] min-w-0 truncate pb-[0.15em] leading-8 text-white lg:text-6xl lg:leading-none"
           data-cy="profile-username-header"
           data-testid="typography"
         >

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
@@ -132,13 +132,16 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
             overrideDefaults
             className="max-width-profile-page-header flex w-full min-w-0 items-center gap-2 sm:max-w-xl lg:max-w-full lg:gap-3"
           >
-            {/* leading-none + ellipsis clips Inter Tight descenders. Clip (not hidden) plus
-                overflow-clip-margin keeps the 60px line and paints the missing ~9px. */}
+            {/* leading-none + ellipsis clips Inter Tight descenders. Bottom padding keeps the
+                missing ~9px inside the clip box (overflow clips at the padding edge) and the
+                negative margin cancels it out of layout, so the 60px line and the emoji
+                alignment hold. Padding instead of overflow-clip-margin: Safari does not
+                support clip-margin, so descenders stayed clipped there. */}
             <Typography
               data-cy="profile-username-header"
               as="h1"
               size="lg"
-              className="min-w-0 overflow-x-clip overflow-y-clip leading-8 text-ellipsis whitespace-nowrap text-white [overflow-clip-margin:0.15em] lg:text-6xl lg:leading-none"
+              className="-mb-[0.15em] min-w-0 truncate pb-[0.15em] leading-8 text-white lg:text-6xl lg:leading-none"
             >
               {name}
             </Typography>

--- a/src/test/vrt/profile/Profile.vrt.test.tsx
+++ b/src/test/vrt/profile/Profile.vrt.test.tsx
@@ -896,10 +896,12 @@ describe('Own profile — posts — visual regression', () => {
     const nameStyle = getComputedStyle(name);
 
     expect(nameStyle.lineHeight).toBe('60px');
-    expect(nameStyle.overflow).toBe('clip');
-    expect(nameStyle.paddingBottom).toBe('0px');
-    expect(nameStyle.marginBottom).toBe('0px');
-    expect(nameStyle.overflowClipMargin).toBe('9px');
+    expect(nameStyle.overflow).toBe('hidden');
+    // Descender room comes from padding (0.15em at 60px), cancelled out of layout
+    // by the matching negative margin — works in WebKit too, unlike the previous
+    // overflow-clip-margin approach (unsupported there, so Safari kept clipping).
+    expect(nameStyle.paddingBottom).toBe('9px');
+    expect(nameStyle.marginBottom).toBe('-9px');
     expect(name.scrollWidth).toBeGreaterThan(name.clientWidth);
     expect(name.getBoundingClientRect().right).toBeLessThan(statusEmoji.getBoundingClientRect().left);
   });


### PR DESCRIPTION
## Summary

- #2422 fixed profile-name descender clipping with `overflow-clip-margin`, but Safari does not support that property (through v27 — [caniuse](https://caniuse.com/mdn-css_properties_overflow-clip-margin)), so descenders (`g`, `y`, `p`) stayed clipped there — and its webkit VRT assertion (`overflowClipMargin === '9px'` → `undefined`) has kept the dev VRT gate red since the merge ([failing run](https://github.com/pubky/pubky-app/actions/runs/32996318538)) and blocks the baseline-regeneration workflow for every branch off dev.
- Swaps the mechanism for one every browser honors: `pb-[0.15em]` gives the descenders the same ~9px of room inside the clip box (overflow clips at the padding edge), and the matching `-mb-[0.15em]` cancels it out of layout so the 60px line and the status-emoji alignment don't move. Same em-scaling as before.
- The VRT test now asserts the padding pair (cross-browser computed styles) instead of `overflowClipMargin`; the layout guards (line height, truncation, emoji boundary) are unchanged.

## Test plan

- [x] `Profile.vrt.test.tsx` passes locally in chromium, firefox and webkit (57/57); darwin baselines unchanged (pixel diff below threshold in chromium/firefox; webkit now paints descenders)
- [x] `ProfilePageHeader.test.tsx` 30/30, snapshots updated
- [x] typecheck / lint / format clean
- [ ] dev `vrt.yml` run goes green after merge

<img width="1245" height="883" alt="image" src="https://github.com/user-attachments/assets/a2615279-9e62-4a76-8eb2-be68200b6354" />