### PR TITLE
tests: fix search e2e and add new search tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -216,6 +216,38 @@ jobs:
 
           echo "Service is ready."
 
+      # TEMP WORKAROUND: nexusd does not create the RediSearch `postContentIdx` index at
+      # startup (only via `nexusd db migration run`), so full-text post search returns 500
+      # ("No such index postContentIdx") on a fresh stack. Run the migrations once after the
+      # stack is up. The migration CLI ignores `--config-dir` and reads
+      # ~/.pubky-nexus/migrations/config.toml, which defaults to localhost, so write a config
+      # pointing at the compose service hostnames first. Remove once Nexus creates the index
+      # on startup.
+      - name: Run Nexus DB migrations (create postContentIdx)
+        run: |
+          docker exec nexusd sh -c 'mkdir -p /root/.pubky-nexus/migrations && cat > /root/.pubky-nexus/migrations/config.toml <<EOF
+          backfill_ready = []
+
+          [stack]
+          log_level = "info"
+          files_path = "/static/files/"
+
+          [stack.otlp]
+          name = "nexusd.migration"
+
+          [stack.db]
+          redis = "redis://nexus-redis:6379"
+
+          [stack.db.neo4j]
+          uri = "bolt://nexus-neo4j:7687"
+          password = "12345678"
+          EOF'
+          docker exec nexusd nexusd db migration run
+          docker exec nexus-redis redis-cli FT._LIST | grep -q postContentIdx || {
+            echo "Error: postContentIdx was not created by Nexus migrations"
+            exit 1
+          }
+
       - name: Run e2e tests - Desktop (${{ matrix.browser }}) - Spec (${{matrix.spec}})
         id: test-desktop
         uses: cypress-io/github-action@v6

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -1,7 +1,10 @@
 import { backupDownloadFilePath } from '../support/common';
 import { slowCypressDown } from 'cypress-slow-down';
 import 'cypress-slow-down/commands';
+import { addTagsToCollectionHero, createCollection, findCollectionCardInSection } from '../support/collections';
+import { goToCollectionsPage, goToProfilePageFromHeader } from '../support/header';
 import { createQuickPost, waitForFeedToLoad } from '../support/posts';
+import { addProfileTags } from '../support/profile';
 import { BackupType, CheckForNewPosts } from '../support/types/enums';
 
 const username = 'Mr Search';
@@ -151,14 +154,40 @@ describe('search', () => {
     cy.get('[data-cy="post-search-results"]').innerTextShouldNotContain(postNoTags);
   });
 
-  // TODO: tag own profile (see `addProfileTags` in support/profile.ts) with a
-  // unique tag, then visit `/search?tags=<tag>` and assert the profile appears
-  // in `[data-cy="search-people-section"]`
-  it('can search people by tag');
+  it('can search people by tag', () => {
+    const profileTag = `person-${uniqueId}`;
 
-  // TODO: create a collection (see `createCollection` and
-  // `addTagsToCollectionHero` in support/collections.ts) with a unique tag, then
-  // visit `/search?tags=<tag>` and assert the collection appears in
-  // `[data-cy="search-collections-section"]`
-  it('can search collections by tag');
+    // tag own profile from the profile 'Tagged' tab
+    goToProfilePageFromHeader();
+    cy.get('[data-cy="profile-filter-item-tagged"]').click();
+    addProfileTags([profileTag]);
+    cy.get('[data-cy="profile-tab-content"]').contains(profileTag);
+
+    // open search results for the profile tag
+    cy.visit(`/search?tags=${profileTag}`);
+    cy.get('[data-cy="header-search"]').innerTextShouldContain(profileTag);
+
+    // confirm the tagged profile is listed in the People section
+    cy.get('[data-cy="search-people-section"]').should('be.visible').innerTextShouldContain(username);
+
+    // no posts carry this tag
+    cy.get('[data-cy="post-search-results"]').find('[data-cy="post-card"]').should('not.exist');
+  });
+
+  it('can search collections by tag', () => {
+    const collectionTag = `collection-${uniqueId}`;
+    const collectionName = `Searchable collection ${uniqueId}`;
+
+    // create a collection and tag it from its hero
+    goToCollectionsPage();
+    createCollection(collectionName, 'Created to be found by tag search.');
+    addTagsToCollectionHero([collectionTag]);
+
+    // open search results for the collection tag
+    cy.visit(`/search?tags=${collectionTag}`);
+    cy.get('[data-cy="header-search"]').innerTextShouldContain(collectionTag);
+
+    // confirm the tagged collection is listed in the Collections section
+    findCollectionCardInSection('[data-cy="search-collections-section"]', collectionName).should('be.visible');
+  });
 });

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -1,16 +1,42 @@
-import { backupDownloadFilePath } from '../support/auth';
+import { backupDownloadFilePath } from '../support/common';
 import { slowCypressDown } from 'cypress-slow-down';
 import 'cypress-slow-down/commands';
 import { createQuickPost, waitForFeedToLoad } from '../support/posts';
-import { CheckForNewPosts } from '../support/types/enums';
+import { BackupType, CheckForNewPosts } from '../support/types/enums';
 
 const username = 'Mr Search';
+
+// unique suffix shared by all tags and posts created in the `before` hook so
+// that each test can rely on the same fixture data
+const uniqueId = Cypress._.uniqueId(Date.now().toString().slice(-2));
+const tag1 = `tag1-${uniqueId}`;
+const tag2 = `tag2-${uniqueId}`;
+const tag3 = `tag3-${uniqueId}`;
+// letters-only unique word so full-text search matches exactly one post even if
+// the index tokenizer splits terms on letter/digit boundaries
+// (content query limits: min 2 chars, max 30 chars, max 4 terms)
+const uniqueWord = `findme${Date.now()
+  .toString()
+  .replace(/\d/g, (digit) => 'abcdefghij'[Number(digit)])}`;
+const postTag1 = `Post with tag1 ${uniqueWord}`;
+const postTag2 = `Post with tag2 ${Date.now()}`;
+const postTags2and3 = `Post with tag2 and tag3 ${Date.now()}`;
+const postNoTags = `Post with no tags ${Date.now()}`;
 
 describe('search', () => {
   before(() => {
     slowCypressDown();
     cy.deleteDownloadsFolder();
-    cy.onboardAsNewUser(username, 'I like to search');
+    cy.onboardAsNewUser(username, 'I like to search', [BackupType.EncryptedFile]);
+
+    // create the posts searched for by the tests below
+    createQuickPost(postTag1, [tag1]);
+    createQuickPost(postTag2, [tag2]);
+    createQuickPost(postTags2and3, [tag2, tag3]);
+    createQuickPost(postNoTags);
+
+    // wait for posts to appear in feed so they are indexed before searching
+    cy.findFirstPostInFeed(CheckForNewPosts.Yes);
   });
 
   beforeEach(() => {
@@ -23,34 +49,7 @@ describe('search', () => {
     });
   });
 
-  it('can search posts by tag filters and by full-text query', () => {
-    const uniqueId = Cypress._.uniqueId(Date.now().toString().slice(-2));
-    const tag1 = `tag1-${uniqueId}`;
-    const tag2 = `tag2-${uniqueId}`;
-    const tag3 = `tag3-${uniqueId}`;
-    // letters-only unique word so full-text search matches exactly one post even if
-    // the index tokenizer splits terms on letter/digit boundaries
-    // (content query limits: min 2 chars, max 30 chars, max 4 terms)
-    const uniqueWord = `findme${Date.now()
-      .toString()
-      .replace(/\d/g, (digit) => 'abcdefghij'[Number(digit)])}`;
-    const postTag1 = `Post with tag1 ${uniqueWord}`;
-    const postTag2 = `Post with tag2 ${Date.now()}`;
-    const postTags2and3 = `Post with tag2 and tag3 ${Date.now()}`;
-    const postNoTags = `Post with no tags ${Date.now()}`;
-
-    // create a post with tag1
-    createQuickPost(postTag1, [tag1]);
-    // create a post with tag2
-    createQuickPost(postTag2, [tag2]);
-    // create a post with tag2 and tag3
-    createQuickPost(postTags2and3, [tag2, tag3]);
-    // create a post with no tags
-    createQuickPost(postNoTags);
-
-    // wait for posts to appear in feed before searching
-    cy.findFirstPostInFeed(CheckForNewPosts.Yes);
-
+  it('can search posts by tag filters', () => {
     // open search results for a single tag
     cy.visit(`/search?tags=${tag1}`);
 
@@ -126,7 +125,9 @@ describe('search', () => {
     cy.location('search').should('contain', `tags=${tag1}`).should('not.contain', tag2);
     cy.get('[data-cy="header-search"]').innerTextShouldContain(tag1).innerTextShouldNotContain(tag2);
     cy.get('[data-cy="post-search-results"]').find('[data-cy="post-card"]').should('have.length', 1);
+  });
 
+  it('can search posts by full-text query', () => {
     // full-text search for the unique word from the first post's text
     cy.get('[data-cy="header-search-input"]').filter(':visible').type(uniqueWord).type('{enter}');
 
@@ -145,5 +146,19 @@ describe('search', () => {
       .within(() => {
         cy.get('[data-cy="post-text"]').innerTextShouldContain(postTag1);
       });
+
+    // a post without the word is not in the results
+    cy.get('[data-cy="post-search-results"]').innerTextShouldNotContain(postNoTags);
   });
+
+  // TODO: tag own profile (see `addProfileTags` in support/profile.ts) with a
+  // unique tag, then visit `/search?tags=<tag>` and assert the profile appears
+  // in `[data-cy="search-people-section"]`
+  it('can search people by tag');
+
+  // TODO: create a collection (see `createCollection` and
+  // `addTagsToCollectionHero` in support/collections.ts) with a unique tag, then
+  // visit `/search?tags=<tag>` and assert the collection appears in
+  // `[data-cy="search-collections-section"]`
+  it('can search collections by tag');
 });

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -163,6 +163,9 @@ describe('search', () => {
     addProfileTags([profileTag]);
     cy.get('[data-cy="profile-tab-content"]').contains(profileTag);
 
+    // wait for nexus to index the profile tag before searching
+    cy.wait(500);
+
     // open search results for the profile tag
     cy.visit(`/search?tags=${profileTag}`);
     cy.get('[data-cy="header-search"]').innerTextShouldContain(profileTag);
@@ -182,6 +185,9 @@ describe('search', () => {
     goToCollectionsPage();
     createCollection(collectionName, 'Created to be found by tag search.');
     addTagsToCollectionHero([collectionTag]);
+
+    // wait for nexus to index the collection tag before searching
+    cy.wait(500);
 
     // open search results for the collection tag
     cy.visit(`/search?tags=${collectionTag}`);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -527,16 +527,11 @@ Cypress.Commands.add(
 );
 
 // useful for finding a specific post card by text in search results
+// `filter` and `eq` are query commands, so the whole chain retries until a matching
+// card renders (a `.then` callback would capture a stale or still-loading result list)
 Cypress.Commands.add('findPostInSearchResults', (filterText?: string, postIdx = 0) => {
-  return cy
-    .get('[data-cy="post-search-results"]')
-    .find('[data-cy="post-card"]')
-    .then(($postCards) => {
-      const filtered = filterText
-        ? $postCards.filter((_idx, element) => element.innerText.includes(filterText))
-        : $postCards;
-      return cy.wrap(filtered).eq(postIdx);
-    });
+  const postCards = cy.get('[data-cy="post-search-results"]').find('[data-cy="post-card"]');
+  return (filterText ? postCards.filter(`:contains("${filterText}")`) : postCards).eq(postIdx);
 });
 
 // To prevent Cypress from failing the test when running pubky-app with dev build:

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -530,8 +530,11 @@ Cypress.Commands.add(
 // `filter` and `eq` are query commands, so the whole chain retries until a matching
 // card renders (a `.then` callback would capture a stale or still-loading result list)
 Cypress.Commands.add('findPostInSearchResults', (filterText?: string, postIdx = 0) => {
-  const postCards = cy.get('[data-cy="post-search-results"]').find('[data-cy="post-card"]');
-  return (filterText ? postCards.filter(`:contains("${filterText}")`) : postCards).eq(postIdx);
+  return cy
+    .get('[data-cy="post-search-results"]')
+    .find('[data-cy="post-card"]')
+    .filter((_idx, element) => (filterText ? element.innerText.includes(filterText) : true))
+    .eq(postIdx);
 });
 
 // To prevent Cypress from failing the test when running pubky-app with dev build:


### PR DESCRIPTION
Fixes failing Search E2E test.
Splits the existing one test into two distinct tests for post search by tag and full text search.
Adds two more tests to cover searching profile and collection by tag.