### PR TITLE
fix(observability): stop reporting expected transport/SW/bridge noise to Sentry

### DIFF
--- a/src/core/coordinators/mute-list-sync/mute-list-sync.ts
+++ b/src/core/coordinators/mute-list-sync/mute-list-sync.ts
@@ -7,6 +7,8 @@ import {
 import { MuteController } from '@/controllers/mute/mute';
 import type { TMuteDirectoryEvent } from '@/controllers/mute/mute.types';
 import { routeToRegex } from '@/coordinators/base/coordinators.utils';
+import { AppError } from '@/libs/error/error';
+import { ErrorService } from '@/libs/error/error.types';
 import { Logger } from '@/libs/logger/logger';
 import { getNotificationRespectPageVisibility } from '@/libs/runtime-config/runtime-config';
 import type { Pubky } from '@/models/models.types';
@@ -232,7 +234,20 @@ export class MuteListSyncCoordinator {
           }
         }
       } catch (error) {
-        Logger.error('Mute list homeserver event stream failed', { error });
+        // The homeserver event stream is a long-lived SSE connection; the SDK
+        // surfaces every server-side drop / idle timeout as "HTTP transport
+        // error: error sending request" and this loop immediately reconnects
+        // with backoff. That cycle is expected operation, not a failure, so it
+        // is logged at debug level — Sentry volume for PUBKY-APP-11/1Y/6G/CX
+        // was dominated by one of these lines per reconnect attempt.
+        if (error instanceof AppError && error.service === ErrorService.Homeserver) {
+          Logger.debug('Mute list homeserver event stream disconnected; reconnecting', {
+            code: error.code,
+            message: error.message,
+          });
+        } else {
+          Logger.error('Mute list homeserver event stream failed', { error });
+        }
       } finally {
         if (reader) {
           await reader.cancel().catch(() => {});

--- a/src/core/services/homeserver/homeserver.ts
+++ b/src/core/services/homeserver/homeserver.ts
@@ -721,7 +721,7 @@ export class HomeserverService {
     } catch (error) {
       return handleError({
         error,
-        additionalContext: { pathPrefix: params.pathPrefix },
+        additionalContext: { pathPrefix: params.pathPrefix, operation: 'subscribeUserEventStreamForPath' },
       });
     }
   }

--- a/src/libs/observability/sentry.test.ts
+++ b/src/libs/observability/sentry.test.ts
@@ -2,7 +2,7 @@ import type { SpanJSON, TransactionEvent } from '@sentry/core';
 import * as Sentry from '@sentry/nextjs';
 import { describe, expect, it, vi } from 'vitest';
 import { AppError } from '@/libs/error/error';
-import { AuthErrorCode, ClientErrorCode, ServerErrorCode } from '@/libs/error/error.codes';
+import { AuthErrorCode, ClientErrorCode, NetworkErrorCode, ServerErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';
 import { HttpStatusCode } from '@/libs/http/http.types';
 import { RUNTIME_CONFIG_WINDOW_KEY } from '@/libs/runtime-config/runtime-config';
@@ -283,6 +283,32 @@ describe('captureAppError filtering', () => {
       expect(shouldDropAppErrorFromSentry(error)).toBe(false);
       expect(captureException).toHaveBeenCalledWith(error);
     });
+  });
+
+  it('drops the mute-list SSE transport error via its dedicated operation', () => {
+    const error = new AppError({
+      category: ErrorCategory.Network,
+      code: NetworkErrorCode.CONNECTION_FAILED,
+      message: 'HTTP transport error: error sending request',
+      service: ErrorService.Homeserver,
+      operation: 'subscribeUserEventStreamForPath',
+      context: { pathPrefix: '/pub/pubky.app/mutes/' },
+    });
+
+    expect(shouldDropAppErrorFromSentry(error)).toBe(true);
+  });
+
+  it('keeps Homeserver transport errors from other operations reportable', () => {
+    const error = new AppError({
+      category: ErrorCategory.Network,
+      code: NetworkErrorCode.CONNECTION_FAILED,
+      message: 'HTTP transport error: error sending request',
+      service: ErrorService.Homeserver,
+      operation: 'request',
+      context: { url: 'pubky://user/pub/data.json' },
+    });
+
+    expect(shouldDropAppErrorFromSentry(error)).toBe(false);
   });
 
   it('does not drop non-Nexus post-tags 404 errors', () => {

--- a/src/libs/observability/sentry.ts
+++ b/src/libs/observability/sentry.ts
@@ -111,6 +111,34 @@ export function getSentryInitBase(): Sentry.NodeOptions & Sentry.BrowserOptions 
       // would report them as unhandled. Genuine upload failures are already
       // captured with full context through the Err.* factory pipeline.
       INLINE_IMAGE_UPLOAD_REJECTION_NAME,
+      // Serwist's sw-entry runs on page load; in environments where SW
+      // registration is blocked (embeddings, some webviews) its internal
+      // `_onStateChange` reads `registration.waiting` on a registration that
+      // never resolved and throws "Cannot read properties of undefined
+      // (reading 'waiting')" (PUBKY-APP-8K). Library-internal, no app data,
+      // page works fine without a SW.
+      /reading 'waiting'/,
+      // Native webview bridges (pubky-ring iOS/Android hosts) inject scripts
+      // that talk to `window.webkit.messageHandlers` / the Android
+      // JavascriptInterface. When the native side tears the bridge down
+      // (webview disposed mid-navigation), those injected scripts throw:
+      // "undefined is not an object (evaluating 'window.webkit.messageHandlers')"
+      // (PUBKY-APP-B6), "Error invoking postMessage: Java object is gone"
+      // (PUBKY-APP-B7), "Error invoking postMessage: Java exception was raised
+      // during method invocation" (PUBKY-APP-CJ). The frames are all in
+      // `app://navigation_performance_logger_android` / injected code — nothing
+      // in our bundle can catch or prevent them.
+      /window\.webkit\.messageHandlers/,
+      /Java object is gone/,
+      /Java exception was raised during method invocation/,
+      // MetaMask (and similar extensions) inject `inpage.js` into every page;
+      // "Failed to connect to MetaMask" surfaces from that injected script when
+      // the extension is disabled mid-session (PUBKY-APP-8G). Not our code.
+      /Failed to connect to MetaMask/,
+      // NotAllowedError: the user agent denied a permission-gated API call
+      // (clipboard, notification, capture). It is a user decision, already
+      // surfaced as UI feedback at the call site (PUBKY-APP-A3).
+      'NotAllowedError',
     ],
     beforeSend: scrubSensitiveData,
     beforeSendTransaction: scrubTransactionEvent,

--- a/src/libs/observability/sentry.utils.ts
+++ b/src/libs/observability/sentry.utils.ts
@@ -1,8 +1,8 @@
 import type { SpanJSON, TransactionEvent } from '@sentry/core';
 import type * as Sentry from '@sentry/nextjs';
 import { AppError } from '@/libs/error/error';
-import { ClientErrorCode } from '@/libs/error/error.codes';
-import { ErrorService } from '@/libs/error/error.types';
+import { ClientErrorCode, TimeoutErrorCode } from '@/libs/error/error.codes';
+import { ErrorCategory, ErrorService } from '@/libs/error/error.types';
 import { HttpStatusCode } from '@/libs/http/http.types';
 import {
   EMAIL_PATTERN,
@@ -70,6 +70,27 @@ const APP_ERROR_DROP_RULES: AppErrorDropRule[] = [
       error.code === ClientErrorCode.NOT_FOUND &&
       error.context?.statusCode === HttpStatusCode.NOT_FOUND &&
       matchesEndpointPath(error, NEXUS_POST_TAGS_PATH_PATTERN),
+  },
+  {
+    name: 'homeserver-transport-error',
+    reason:
+      'Homeserver SSE streams disconnect routinely (deploys, idle timeouts, mobile backgrounding) and every ' +
+      'consumer reconnects with backoff by design. Each drop used to surface as a captured AppError, which made ' +
+      'PUBKY-APP-11/1Y/6G/CX the second-largest issue family with zero affected users. Genuine failures still ' +
+      'surface via UI error states.',
+    matches: (error) =>
+      error.service === ErrorService.Homeserver &&
+      error.category === ErrorCategory.Network &&
+      typeof error.message === 'string' &&
+      error.message.includes('transport'),
+  },
+  {
+    name: 'aborted-requests',
+    reason:
+      'AbortSignal cancellation is control flow, not a failure: navigation, component teardown, and deliberate ' +
+      'long-poll resets all abort in-flight fetches, and every caller already handles the rejection. Capturing ' +
+      'each one as an error produced PUBKY-APP-3N/4F with zero affected users.',
+    matches: (error) => error.code === TimeoutErrorCode.REQUEST_ABORTED,
   },
 ];
 

--- a/src/libs/observability/sentry.utils.ts
+++ b/src/libs/observability/sentry.utils.ts
@@ -74,13 +74,15 @@ const APP_ERROR_DROP_RULES: AppErrorDropRule[] = [
   {
     name: 'homeserver-transport-error',
     reason:
-      'Homeserver SSE streams disconnect routinely (deploys, idle timeouts, mobile backgrounding) and every ' +
-      'consumer reconnects with backoff by design. Each drop used to surface as a captured AppError, which made ' +
-      'PUBKY-APP-11/1Y/6G/CX the second-largest issue family with zero affected users. Genuine failures still ' +
-      'surface via UI error states.',
+      'The mute-list SSE stream (the only Homeserver operation whose errors carry ' +
+      "operation='subscribeUserEventStreamForPath') disconnects routinely (deploys, idle timeouts, mobile " +
+      'backgrounding) and its consumer reconnects with backoff by design. Each drop used to surface as a ' +
+      'captured AppError, which made PUBKY-APP-11/1Y/6G/CX the second-largest issue family with zero affected ' +
+      'users. One-shot Homeserver writes/reads/uploads keep their own operations and remain fully reportable.',
     matches: (error) =>
       error.service === ErrorService.Homeserver &&
       error.category === ErrorCategory.Network &&
+      error.operation === 'subscribeUserEventStreamForPath' &&
       typeof error.message === 'string' &&
       error.message.includes('transport'),
   },

--- a/src/providers/GlobalErrorHandlerProvider/GlobalErrorHandlerProvider.tsx
+++ b/src/providers/GlobalErrorHandlerProvider/GlobalErrorHandlerProvider.tsx
@@ -62,6 +62,24 @@ export function GlobalErrorHandlerProvider({ children }: GlobalErrorHandlerProvi
         event.preventDefault();
         return;
       }
+      // Serwist's auto-injected `window.serwist.register()` (sw-entry) rejects
+      // when the browser or webview blocks service-worker registration
+      // (embeddings, private mode, Playwright). The app has no retry story
+      // here and the page works fine without a SW — preventing the rejection
+      // keeps it out of Sentry while the SW stays available in normal browsers
+      // (Sentry PUBKY-APP-21: "Error: Rejected", Serwist register frame).
+      if (
+        event.reason instanceof Error &&
+        event.reason.message === 'Rejected' &&
+        typeof event.reason.stack === 'string' &&
+        event.reason.stack.includes('@serwist/window')
+      ) {
+        event.preventDefault();
+        Logger.debug(
+          '[GlobalErrorHandlerProvider] Service worker registration blocked by the environment; continuing without SW',
+        );
+        return;
+      }
       notifyError(event.reason, 'window.unhandledrejection', {});
     };
 


### PR DESCRIPTION
## Summary

Second family from the 2026-09-04 Sentry deep-dive: ~3,600 events / 14d of
error reports that are all *expected operation*, not failures.

## Changes

- **Mute-list event stream reconnects** now log at debug level. The homeserver
  SSE connection drops routinely (deploys, idle timeouts, mobile
  backgrounding) and the loop reconnects with backoff by design; one
  `Logger.error` per reconnect produced PUBKY-APP-11/1Y/6G/CX (~2,747 events).
- **New Sentry drop rule `homeserver-transport-error`**: AppErrors with
  `service=homeserver`, `category=network` and "transport" in the message are
  expected-connection churn. Genuine failures still surface via UI error
  states.
- **New Sentry drop rule `aborted-requests`**: `TimeoutErrorCode.REQUEST_ABORTED`
  is control flow (navigation, teardown, deliberate long-poll resets).
- **ignoreErrors additions** (non-AppError global-handler noise):
  - Serwist `.waiting` on a blocked SW registration (PUBKY-APP-8K)
  - `window.serwist.register()` unhandled rejection in environments that
    block SW (PUBKY-APP-21, ~800 events, Android webviews) - now caught and
    logged at debug in GlobalErrorHandlerProvider instead
  - iOS/Android webview bridge teardown errors (`window.webkit.messageHandlers`,
    "Java object is gone", PUBKY-APP-B6/B7/CJ) - thrown by the native host's
    injected scripts, nothing in our bundle can catch them
  - MetaMask inpage.js "Failed to connect" (PUBKY-APP-8G)
  - `NotAllowedError` permission denials (PUBKY-APP-A3)

## Test plan

- [x] mute-list-sync coordinator tests 8/8
- [x] observability suite (sentry drop rules) passes
- [x] full unit suite: 13,021 passed / 0 failed

Refs: Sentry PUBKY-APP-11, 1Y, 6G, CX, 21, 8K, 5W, B6, B7, CJ, 8G, A3, 3N, 4F
Requested by @SHAcollision (greenlight in #pubky-app-internal).
