### PR TITLE
[Locks] feat(#2368): pay with Bitkit to unlock a post

### DIFF
--- a/docs/locks.md
+++ b/docs/locks.md
@@ -5,8 +5,9 @@ teaser advertising it. This doc starts with the mental model — what is differe
 rest of the app — and gets more detailed the further down you read. If you know pubky-app
 but not locks, read top to bottom.
 
-Phase 1 (epic **#1998**) ships **password locks only** — payment comes later. See
-[Phase 1 & release-gate markers](#phase-1--release-gate-markers) for what is deliberately
+Phase 2 (epic **#2364**) makes locks **payable**: a creator sets a price in sats and the
+reader pays it from Bitkit. The Phase 1 password lock still exists until **#2369** deletes
+it. See [Phase 1 & marker tracking](#phase-1--marker-tracking) for what is deliberately
 temporary.
 
 ## Table of contents
@@ -28,9 +29,9 @@ temporary.
 ## What a lock is
 
 To the user: a post in the feed that looks normal — a short teaser, maybe an image — with a
-lock card on top ("Secret essay · Unlock"). Entering the password (Phase 1) reveals the
-real content in place: a post, an article, images, files. Everything the user unlocked is
-listed on their own profile under **Unlocked**.
+lock card on top ("Secret essay · Unlock ₿1,000"). Paying the price from Bitkit (or, until
+#2369, entering the password) reveals the real content in place: a post, an article, images,
+files. Everything the user unlocked is listed on their own profile under **Unlocked**.
 
 Two roles: the **creator** publishes locked content behind a public announcement; the
 **reader** unlocks and reads it.
@@ -70,10 +71,11 @@ article button while the lock switch is on (`PostInputExpandableSection`), and
 (`core/pipes/post/post.kind.ts`), which throws on those two kinds. The guard is the
 backstop for the UI rule, so a UI change can't loosen it silently.
 
-**2. Unlock (reader).** The lock card opens a password dialog. The FE submits a **proof**
-(evidence the unlock criteria are met — in Phase 1, the password) to the Lock Server,
-polls until verified, gets a short-lived credential, proxy-reads the guarded bytes with
-it — and then **replicates** them into the reader's own `/priv`.
+**2. Unlock (reader).** The lock card opens the unlock dialog for the lock's kind — Pay to
+Unlock for a payment lock, a password prompt until #2369. Either way the FE submits a
+**proof** to the Lock Server, waits until it verifies (for a payment: until the reader has
+paid in Bitkit), gets a short-lived credential, proxy-reads the guarded bytes with it — and
+then **replicates** them into the reader's own `/priv`.
 Details: [Reading a lock post](#reading-a-lock-post).
 
 **3. Read again.** Every later view skips the Lock Server entirely: the post renders from
@@ -83,11 +85,12 @@ replica also survives the creator revoking the lock. Details:
 
 ## Where the data lives
 
-| Where                                         | What                                      | Who can read it                                              |
-| --------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------ |
-| creator's HS `/priv/locks.app/content/`       | the locked post + attachments (originals) | the creator; readers only via Lock Server proxy + credential |
-| creator's HS `/pub/locks.app/<lockId>.json`   | the public lock contract (`LockFile`)     | anyone                                                       |
-| reader's HS `/priv/social/unlocked/<lockId>/` | the reader's replica, written on unlock   | that reader only                                             |
+| Where                                              | What                                                                    | Who can read it                                              |
+| -------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------ |
+| creator's HS `/priv/locks.app/content/`            | the locked post + attachments (originals)                               | the creator; readers only via Lock Server proxy + credential |
+| creator's HS `/pub/locks.app/<lockId>.json`        | the public lock contract (`LockFile`)                                   | anyone                                                       |
+| reader's HS `/priv/social/unlocked/<lockId>/`      | the reader's replica, written on unlock                                 | that reader only                                             |
+| reader's HS `/priv/social/purchases/<lockId>.json` | the purchase's bundle id, written BEFORE the proof is submitted (#2297) | that reader only                                             |
 
 ---
 
@@ -143,6 +146,10 @@ and swaps in the guarded post once it becomes readable.
 | `components/organisms/PostBody/PostBody.tsx`                       | shared text + link-embed + attachment renderer (feed post body **and** lock teaser) |
 | `components/molecules/LockedPostCard/LockedPostCard.tsx`           | lock card: title, shield graphic, Unlock control (also used by the composer)        |
 | `components/molecules/DialogUnlockContent/DialogUnlockContent.tsx` | password prompt                                                                     |
+| `components/molecules/DialogPayToUnlock/DialogPayToUnlock.tsx`     | Pay to Unlock modal (checking / pay / install / waiting / blocked)                  |
+| `hooks/usePayToUnlock/usePayToUnlock.ts`                           | the payment state machine: bundle-id routing, submit, polling, stall/resume         |
+| `hooks/usePurchasedLocks/usePurchasedLocks.ts`                     | one listing of the reader's purchases, shared by every lock post                    |
+| `hooks/usePurchaseResume/usePurchaseResume.ts`                     | finishes a paid purchase whose content never landed, without interaction            |
 
 ## Reading a lock post
 
@@ -154,18 +161,22 @@ LockedPostContent
   ├─ useLockFile(lock)                       → lock.json (LockFile | null)
   │    └─ LocksController.fetchLockFile      → LocksApplication → LocksService.readContentLock
   │
-  └─ useUnlockedContent(lock, lockFile, authorId)
-       ├─ 1) already unlocked as a reader → fetchReplicatedContent  (my HS /priv copy)
-       ├─ 2) my own post (a == b)         → fetchOwnContent         (my HS /priv original)
-       └─ 3) neither → lock card → DialogUnlockContent → unlock (below)
+  ├─ useUnlockedContent(lock, lockFile, authorId)
+  │    ├─ 1) already unlocked as a reader → fetchReplicatedContent  (my HS /priv copy)
+  │    ├─ 2) my own post (a == b)         → fetchOwnContent         (my HS /priv original)
+  │    └─ 3) neither → lock card → unlock (below)
+  │             ├─ password lock → DialogUnlockContent
+  │             └─ payment lock  → DialogPayToUnlock (sign-in required first)
+  └─ 4) saved purchase, no replica → usePurchaseResume → fetchPaidContentIfCompleted
 ```
 
 `a == b` is team shorthand: **a** = the announcement's author account, **b** = the account
 that owns the lock (Lock Server side). Phase 1 assumes they are the same person, and
 own-content reads rely on it.
 
-**Unlock** (`LocksApplication.unlockContent`) — steps 1–4 run against the Lock Server and
-need no pubky.app session; step 5 writes to the reader's homeserver with it:
+**Password unlock** (`LocksApplication.unlockContent`) — one blocking call; steps 1–4 run
+against the Lock Server and need no pubky.app session; step 5 writes to the reader's
+homeserver with it. Goes away with #2369:
 
 1. `submitProofBundle` — proof built from `lock.json` by `LockProofBundler`
 2. `lookupVerificationTask` — poll every 1.5s, max 40 attempts, until `completed`
@@ -174,6 +185,47 @@ need no pubky.app session; step 5 writes to the reader's homeserver with it:
 5. `replicateUnlockedContent` — copy into the reader's own `/priv/social/unlocked/<lockId>/`,
    **attachments first, `post.json` last** (the completion marker), so a partial copy is
    never mistaken for an unlocked post
+
+**Payment unlock** (#2368) is the same pipeline split into steps the modal drives, because a
+real payment takes minutes and happens in Bitkit, not the browser. `usePayToUnlock` owns the
+state machine:
+
+1. On open: `fetchPurchaseBundleId` — the reader's `/priv/social/purchases/<lockId>.json` holds
+   the bundle id of a purchase in flight (#2297). It is the ONLY handle to reach a purchase
+   again (the reader is anonymous to the Lock Server), so it is written **before** the proof
+   is submitted, kept after replication, and a failed read blocks paying (fail closed).
+2. Route by the server's answer (`fetchPaymentStatus`; SDK 404 maps to `null`): no task → the submission never landed,
+   Pay again with the SAME id; `pending`/`in_progress` → waiting + polling; `completed` →
+   credential; `failed`/`expired` → a fresh id (those cannot be retried).
+3. Pressing **Pay with Bitkit** (or **I completed the steps** on the no-wallet screen) is the
+   start of the payment: `startPayment` saves the id, then submits the proof (empty payload, reader pubky at
+   the bundle's top level), then wait. Paykit delivers the payment request to the reader's
+   wallet; the app never sees an address or invoice.
+4. Waiting polls every **3 seconds** and has **no server deadline** — polling stops on a wall clock (3 min) without failing
+   the purchase, re-checks when the tab becomes visible again (the reader was in Bitkit), and
+   offers a **Check again** button so a reader who never left the tab is not stuck on a spinner.
+5. Turning a completed payment into content (credential → read) parks the same way when it fails,
+   and **Check again** runs it again. Retrying is free — the entitlement is durable and the
+   credential is minted fresh each time, which is also why an expired credential needs no detection.
+   Once the content is ready, the modal shows the paid confirmation; **View Content** closes it and
+   reveals the guarded post.
+
+Closing during submission or waiting opens a confirmation dialog. Closing only stops this tab's
+polling; the server-side payment continues and reopening resumes it from the saved bundle id.
+
+Two tabs can still race between choosing and saving a bundle id; the post-write read-back that
+elects the stored winner is deferred to #2468.
+
+**Paid but never received.** The payment completes on the server whether or not the browser is
+watching, so a reader who closes the tab mid-wait would come back to a post still offering Unlock
+over content they own. `usePurchaseResume` closes that gap: it finishes the purchase in the
+background, with no interaction. What tells it a lock is already paid for is
+`usePurchasedLocks` — **one listing** of `/priv/social/purchases/` per reader per page load,
+shared by every lock post on screen, so the feed never asks per post.
+
+The wallet gate (`hasPaykitReceiver`) decides between the pay and install screens; it reports
+presence only, so a submission can still fail afterwards (one `502` covers both "wallet not
+ready" and "Paykit down" — a distinct code is a pending ask on the locks side).
 
 Replication is what makes path 1 work on later views: no Lock Server call, and the content
 survives the creator revoking access.
@@ -201,15 +253,21 @@ screen does not re-read every marker.
 | pipe        | `core/pipes/locks/locks.parser.ts`   | `LockContentParser`, `LockFileParser`, `GuardedContentParser`, `LockProofBundler` (pure) |
 | types       | `core/services/locks/locks.types.ts` | `LockFile`, `lockPostContentSchema`, `VerifierType`, guarded-post schemas                |
 
+Locks has no local-first controller write, so its server actions do not use the `commit*`
+prefix: `hasPaykitReceiver` is a server query and `startPayment` is a server workflow action.
+This temporary naming exception will be resolved in #2296.
+
 Notes:
 
 - **Own-lock reads require both checks.** `lock.json` is public, so anyone can point their
   own post at someone else's lock URL — `useUnlockedContent` treats a lock as mine only
   when the lock creator **and** the post author are the signed-in user.
 - **Reads wait for the restored session.** `currentUserPubky` is persisted and rehydrates
-  before the homeserver session exists; both `/priv` reads gate on the session.
-- **Single error origin.** Validation throws `Err.validation` in the application (the
-  factory logs + reports to Sentry once). Hooks catch and degrade to the lock card.
+  before the homeserver session exists; every reader-side `/priv` read gates on the session —
+  the replica, the own-content read, and the saved bundle id (without the gate a purchase in
+  flight would read back as "none" and offer to pay again).
+- **Single error origin.** Validation throws `Err.validation` in the application (the factory
+  logs + reports to Sentry once). Hooks catch and degrade to the lock card.
 - **Read path.** This is a read flow; there is no local-first `commit*` write.
 
 ## The Unlocked screen
@@ -247,9 +305,10 @@ Phase 1 (epic **#1998**) was password locks only: every criterion used a `dev-st
 placeholder that always passes. Phase 2 (**#2364**) adds the price: a payment lock writes a
 single `paykit-payment` criterion instead, holding the recipient (always the lock's creator),
 the amount in sats as a string, and `BTC` as the asset. The password path still writes
-`dev-static` until **#2369** removes it. Reader-side payment is **#2368**, so a payment lock
-cannot be unlocked from pubky-app yet. Creator-configurable credential TTLs and IndexedDB
-caching still come later.
+`dev-static` until **#2369** removes it. Reader-side payment (**#2368**) is in: a payment
+lock is unlocked by paying from Bitkit (see
+[Reading a lock post](#reading-a-lock-post)). Creator-configurable credential TTLs and
+IndexedDB caching still come later.
 
 Every dev / temporary shortcut carries the ticket number that owns it —
 `grep -rn "TODO:\[Locks\]" src/` lists them, and each number is the issue to read.
@@ -260,6 +319,9 @@ Use `grep -rniE "TODO.*lock" src/` to catch one that lost its tag.
 **The Lock SDK is not on npm yet** (as of 2026-08). `@pubky/locks-sdk` is deliberately
 missing from `package.json` — you build it from the `pubky/locks` repo and copy it into
 `node_modules` by hand:
+
+Until `pubky/locks#42` lands, build the SDK from that PR branch; the payment wallet gate
+depends on its `Locks.hasPaykitDataWithOptions` API.
 
 ```bash
 cd <locks repo>/locks-sdk/bindings/js
@@ -280,4 +342,5 @@ the copy — if lock imports suddenly fail or behave stale, re-copy first.
 - Lock server FE integration: `pubky/locks` → `docs/_front_end_integration.md` — the
   `lock.json` shape and the submit-proof → credential → proxy-read access flow.
 - Creator side: [ADR 0019](adr/0019-locks-creator-publishing.md)
-- Issues: #2003 (reader), #1998 (locks epic / Phase 1), #2040 (release-gate audit).
+- Issues: #2297 (bundle-id persistence), #2368 (reader payment), #2468 (multi-tab read-back),
+  #2369 (password-lock removal), #1998 (Phase 1 epic).

--- a/docs/locks.md
+++ b/docs/locks.md
@@ -255,7 +255,9 @@ screen does not re-read every marker.
 
 Locks has no local-first controller write, so its server actions do not use the `commit*`
 prefix: `hasPaykitReceiver` is a server query and `startPayment` is a server workflow action.
-This temporary naming exception will be resolved in #2296.
+The purchase bundle id file and the purchases listing are always read from the homeserver and
+never cached: they decide whether a payment is reused, so a stale copy could cost money. (#2296
+caches lock files and replicas, which do not change; it does not cover these.)
 
 Notes:
 

--- a/src/components/molecules/AppDownload/AppDownload.tsx
+++ b/src/components/molecules/AppDownload/AppDownload.tsx
@@ -1,0 +1,38 @@
+import { Container } from '@/atoms/Container/Container';
+import { Image } from '@/atoms/Image/Image';
+import { Link } from '@/atoms/Link/Link';
+
+interface AppDownloadProps {
+  logo: { src: string; alt: string; width: number };
+  appStoreUrl: string;
+  playStoreUrl: string;
+  layout?: 'row' | 'column';
+}
+
+/** App wordmark and its two store badges. */
+export function AppDownload({ logo, appStoreUrl, playStoreUrl, layout = 'column' }: AppDownloadProps) {
+  const badges = (
+    <>
+      <Link href={appStoreUrl} target="_blank">
+        <Image src="/images/badge-apple.webp" alt="App Store" width={72} height={24} />
+      </Link>
+      <Link href={playStoreUrl} target="_blank">
+        <Image src="/images/badge-android.webp" alt="Google Play" width={81} height={24} />
+      </Link>
+    </>
+  );
+
+  return (
+    <Container
+      overrideDefaults={layout === 'row'}
+      className={layout === 'row' ? 'flex flex-wrap items-center gap-3.5' : 'flex flex-col items-center gap-4'}
+    >
+      <Image src={logo.src} alt={logo.alt} width={logo.width} height={32} />
+      {layout === 'row' ? (
+        badges
+      ) : (
+        <Container className="flex flex-row items-center justify-center gap-3.5">{badges}</Container>
+      )}
+    </Container>
+  );
+}

--- a/src/components/molecules/DialogLockContent/DialogLockContent.tsx
+++ b/src/components/molecules/DialogLockContent/DialogLockContent.tsx
@@ -11,6 +11,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/atoms/Tabs/Tabs';
 import { Typography } from '@/atoms/Typography/Typography';
 import { useBtcRate } from '@/hooks/useSatUsdRate/useSatUsdRate';
 import { calculatePasswordStrength } from '@/libs/password/password';
+import { formatSats } from '@/libs/utils/formatSats';
 import { cn } from '@/libs/utils/utils';
 import type { DialogLockContentProps, LockMethod } from './DialogLockContent.types';
 
@@ -25,7 +26,6 @@ const PASSWORD_RULE_LABELS: Record<string, string> = {
   special: 'At least 1 special character',
 };
 
-const satsFormatter = new Intl.NumberFormat('en-US');
 const usdFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
 
 // Only the leading run of digits counts. Grouping separators go first so the formatted value the
@@ -205,7 +205,7 @@ export function DialogLockContent({ open, onOpenChange, onApplied }: DialogLockC
                     <Input
                       id="lock-amount"
                       inputMode="numeric"
-                      value={amount ? satsFormatter.format(amountSats) : ''}
+                      value={amount ? (formatSats(amountSats, { symbol: false }) ?? '') : ''}
                       onChange={(event) => setAmount(toSats(event.target.value))}
                       placeholder="0"
                       className="h-auto flex-1 border-0 bg-transparent p-0 text-base shadow-none"

--- a/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.test.tsx
+++ b/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.test.tsx
@@ -1,0 +1,209 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { TPayToUnlockStage } from '@/hooks/usePayToUnlock/usePayToUnlock.types';
+import { DialogPayToUnlock } from './DialogPayToUnlock';
+
+vi.mock('@/hooks/useUserProfile/useUserProfile', () => ({
+  useUserProfile: () => ({ profile: { name: 'John Carvalho', avatarUrl: undefined }, isLoading: false }),
+}));
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: (selector: (s: { currentUserPubky: string | null }) => unknown) =>
+    selector({ currentUserPubky: 'reader1' }),
+}));
+
+const renderDialog = (
+  stage: TPayToUnlockStage,
+  overrides: {
+    isSubmitting?: boolean;
+    onSubmit?: () => void;
+    isStalled?: boolean;
+    onRecheck?: () => void;
+    onViewContent?: () => void;
+    onOpenChange?: (open: boolean) => void;
+    wrapper?: React.JSXElementConstructor<{ children: React.ReactNode }>;
+  } = {},
+) =>
+  render(
+    <DialogPayToUnlock
+      open
+      onOpenChange={overrides.onOpenChange ?? vi.fn()}
+      lockTitle="My locked post"
+      authorId="pubkycreator"
+      priceSats="1000"
+      stage={stage}
+      isStalled={overrides.isStalled ?? false}
+      isSubmitting={overrides.isSubmitting ?? false}
+      onSubmit={overrides.onSubmit ?? vi.fn()}
+      onRecheck={overrides.onRecheck ?? vi.fn()}
+      onViewContent={overrides.onViewContent ?? vi.fn()}
+    />,
+    { wrapper: overrides.wrapper },
+  );
+
+describe('DialogPayToUnlock', () => {
+  it('always shows the grouped price and the creator', () => {
+    renderDialog('pay');
+    expect(screen.getByText('₿ 1,000')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'J' })).toHaveAttribute('href', '/profile/pubkycreator');
+  });
+
+  // The wallet may live on another device, so the store links stay next to the price on both screens.
+  it('shows the Bitkit links on the pay screen too', () => {
+    renderDialog('pay');
+    expect(screen.getByRole('link', { name: 'App Store' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Google Play' })).toBeInTheDocument();
+  });
+
+  it('pay: shows the Bitkit instruction and the Pay button', () => {
+    const onSubmit = vi.fn();
+    renderDialog('pay', { onSubmit });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pay with Bitkit' }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('install: shows the setup steps, store links, and the completed-steps button', () => {
+    const onSubmit = vi.fn();
+    renderDialog('install', { onSubmit });
+
+    expect(screen.getByText(/Install Bitkit/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'App Store' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Google Play' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'I completed the steps' }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  // Nothing to cancel past submission — the purchase continues server-side, so the button only closes.
+  it('waiting: shows the awaiting label, no primary button, and Close instead of Cancel', () => {
+    renderDialog('waiting');
+
+    expect(screen.getByText('AWAITING PAYMENT')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Pay with Bitkit|I completed the steps/ })).not.toBeInTheDocument();
+    // The footer button reads Close (the X in the corner is also named Close, hence the data-cy hook).
+    expect(document.querySelector('[data-cy="pay-to-unlock-cancel"]')).toHaveTextContent('Close');
+  });
+
+  // Parked is not failed: a reader who never leaves the tab gets no visibility event, so the only
+  // way back to a live purchase is an explicit re-check.
+  it('waiting + stalled: swaps the spinner for a Check again button', () => {
+    const onRecheck = vi.fn();
+    renderDialog('waiting', { isStalled: true, onRecheck });
+
+    expect(screen.queryByText('AWAITING PAYMENT')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Check again' }));
+    expect(onRecheck).toHaveBeenCalledTimes(1);
+  });
+
+  it('checking: renders no primary button while the purchase state resolves', () => {
+    renderDialog('checking');
+    expect(screen.queryByRole('button', { name: /Pay with Bitkit|I completed the steps/ })).not.toBeInTheDocument();
+  });
+
+  it('blocked: explains the failed check and offers no way to pay', () => {
+    renderDialog('blocked');
+    expect(screen.getByText(/could not be checked/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Pay with Bitkit|I completed the steps/ })).not.toBeInTheDocument();
+  });
+
+  it('paid: shows the Figma confirmation state and reveals content only from its button', () => {
+    const onViewContent = vi.fn();
+    renderDialog('paid', { onViewContent });
+
+    expect(screen.getByRole('heading', { name: 'Unlocked' })).toBeInTheDocument();
+    expect(screen.getByText('PAYMENT RECEIVED')).toHaveClass('text-brand');
+    expect(screen.getByText('₿ 1,000')).toBeInTheDocument();
+    expect(screen.getByText('Unlocked. Thank you for supporting creators!')).toBeInTheDocument();
+    expect(document.querySelector('.lucide-circle-check')).toHaveClass('size-[72px]');
+    expect(document.querySelector('.lucide-circle-check')).toHaveAttribute('stroke-width', '0.5');
+    expect(document.querySelector('[data-cy="pay-to-unlock-cancel"]')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Content' }));
+    expect(onViewContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('paid: closing reveals the content already in memory', () => {
+    const onViewContent = vi.fn();
+    const onOpenChange = vi.fn();
+    renderDialog('paid', { onViewContent, onOpenChange });
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+    expect(onViewContent).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('waiting: the close button asks before it closes', () => {
+    const onOpenChange = vi.fn();
+    renderDialog('waiting', { onOpenChange });
+
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-cancel"]') as HTMLElement);
+    expect(screen.getByText('The payment is still running')).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('waiting: Keep waiting dismisses the prompt and leaves the modal open', () => {
+    const onOpenChange = vi.fn();
+    renderDialog('waiting', { onOpenChange });
+
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-cancel"]') as HTMLElement);
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-keep-waiting"]') as HTMLElement);
+    expect(screen.queryByText('The payment is still running')).not.toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('waiting: Close anyway closes the modal', () => {
+    const onOpenChange = vi.fn();
+    renderDialog('waiting', { onOpenChange });
+
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-cancel"]') as HTMLElement);
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-close-anyway"]') as HTMLElement);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // Nothing is in flight before the payment starts, so that close needs no prompt.
+  it('pay: the cancel button closes without asking while nothing has been submitted', () => {
+    const onOpenChange = vi.fn();
+    renderDialog('pay', { onOpenChange });
+
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-cancel"]') as HTMLElement);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(screen.queryByText('The payment is still running')).not.toBeInTheDocument();
+  });
+
+  // The submission is in flight before the stage flips to waiting; closing then must still ask.
+  it('pay: asks before closing while a submission is in flight', () => {
+    const onOpenChange = vi.fn();
+    renderDialog('pay', { onOpenChange, isSubmitting: true });
+
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-cancel"]') as HTMLElement);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.getByText('The payment is still running')).toBeInTheDocument();
+
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-close-anyway"]') as HTMLElement);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('locks the primary button while a submission is in flight', () => {
+    renderDialog('pay', { isSubmitting: true });
+    expect(document.querySelector('[data-cy="pay-to-unlock-submit"]')).toBeDisabled();
+  });
+
+  // Escape goes through Radix, not the footer button, so the confirm prompt has to catch that path too.
+  it('waiting: Escape asks before closing', () => {
+    const onOpenChange = vi.fn();
+    renderDialog('waiting', { onOpenChange });
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(screen.getByText('The payment is still running')).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  // The dialog is portaled, but React still bubbles its clicks to the post card, which would navigate.
+  it('clicks inside the dialog do not reach the post card', () => {
+    const cardClick = vi.fn();
+    renderDialog('pay', { wrapper: ({ children }) => <div onClick={cardClick}>{children}</div> });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pay with Bitkit' }));
+    expect(cardClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.test.tsx
+++ b/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.test.tsx
@@ -132,6 +132,31 @@ describe('DialogPayToUnlock', () => {
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
+  // The payment went through here, so the waiting copy ("pay in Bitkit, then check again") would
+  // be telling a reader who already paid to pay again.
+  it('unopened: says the payment landed and offers the retry, with no cost to pay', () => {
+    const onRecheck = vi.fn();
+    renderDialog('unopened', { onRecheck });
+
+    expect(screen.getByText('PAYMENT RECEIVED')).toHaveClass('text-brand');
+    expect(screen.getByText(/could not be opened/)).toBeInTheDocument();
+    expect(screen.queryByText(/Pay in Bitkit/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Pay with Bitkit/ })).not.toBeInTheDocument();
+
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-recheck"]') as HTMLElement);
+    expect(onRecheck).toHaveBeenCalledTimes(1);
+  });
+
+  // Nothing is running behind it, so this close needs no confirmation.
+  it('unopened: closes without asking', () => {
+    const onOpenChange = vi.fn();
+    renderDialog('unopened', { onOpenChange });
+
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-cancel"]') as HTMLElement);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(screen.queryByText('The payment is still running')).not.toBeInTheDocument();
+  });
+
   it('waiting: the close button asks before it closes', () => {
     const onOpenChange = vi.fn();
     renderDialog('waiting', { onOpenChange });

--- a/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.test.tsx
+++ b/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.test.tsx
@@ -11,34 +11,34 @@ vi.mock('@/stores/auth/auth.store', () => ({
     selector({ currentUserPubky: 'reader1' }),
 }));
 
-const renderDialog = (
-  stage: TPayToUnlockStage,
-  overrides: {
-    isSubmitting?: boolean;
-    onSubmit?: () => void;
-    isStalled?: boolean;
-    onRecheck?: () => void;
-    onViewContent?: () => void;
-    onOpenChange?: (open: boolean) => void;
-    wrapper?: React.JSXElementConstructor<{ children: React.ReactNode }>;
-  } = {},
-) =>
-  render(
-    <DialogPayToUnlock
-      open
-      onOpenChange={overrides.onOpenChange ?? vi.fn()}
-      lockTitle="My locked post"
-      authorId="pubkycreator"
-      priceSats="1000"
-      stage={stage}
-      isStalled={overrides.isStalled ?? false}
-      isSubmitting={overrides.isSubmitting ?? false}
-      onSubmit={overrides.onSubmit ?? vi.fn()}
-      onRecheck={overrides.onRecheck ?? vi.fn()}
-      onViewContent={overrides.onViewContent ?? vi.fn()}
-    />,
-    { wrapper: overrides.wrapper },
-  );
+type DialogOverrides = {
+  isSubmitting?: boolean;
+  onSubmit?: () => void;
+  isStalled?: boolean;
+  onRecheck?: () => void;
+  onViewContent?: () => void;
+  onOpenChange?: (open: boolean) => void;
+  wrapper?: React.JSXElementConstructor<{ children: React.ReactNode }>;
+};
+
+const dialogElement = (stage: TPayToUnlockStage, overrides: DialogOverrides = {}) => (
+  <DialogPayToUnlock
+    open
+    onOpenChange={overrides.onOpenChange ?? vi.fn()}
+    lockTitle="My locked post"
+    authorId="pubkycreator"
+    priceSats="1000"
+    stage={stage}
+    isStalled={overrides.isStalled ?? false}
+    isSubmitting={overrides.isSubmitting ?? false}
+    onSubmit={overrides.onSubmit ?? vi.fn()}
+    onRecheck={overrides.onRecheck ?? vi.fn()}
+    onViewContent={overrides.onViewContent ?? vi.fn()}
+  />
+);
+
+const renderDialog = (stage: TPayToUnlockStage, overrides: DialogOverrides = {}) =>
+  render(dialogElement(stage, overrides), { wrapper: overrides.wrapper });
 
 describe('DialogPayToUnlock', () => {
   it('always shows the grouped price and the creator', () => {
@@ -158,6 +158,23 @@ describe('DialogPayToUnlock', () => {
     fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-cancel"]') as HTMLElement);
     fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-close-anyway"]') as HTMLElement);
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // Polling never stopped under the prompt, so the payment can land while it is up. Closing then
+  // must reveal the content already downloaded — dropping it leaves the background recovery to mint
+  // a second credential and fetch the same post again.
+  it('waiting: Close anyway reveals content that arrived while the prompt was up', () => {
+    const overrides = { onViewContent: vi.fn(), onOpenChange: vi.fn() };
+    const { rerender } = renderDialog('waiting', overrides);
+
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-cancel"]') as HTMLElement);
+    expect(screen.getByText('The payment is still running')).toBeInTheDocument();
+
+    rerender(dialogElement('paid', overrides));
+    fireEvent.click(document.querySelector('[data-cy="pay-to-unlock-close-anyway"]') as HTMLElement);
+
+    expect(overrides.onViewContent).toHaveBeenCalledTimes(1);
+    expect(overrides.onOpenChange).not.toHaveBeenCalled();
   });
 
   // Nothing is in flight before the payment starts, so that close needs no prompt.

--- a/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.tsx
+++ b/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import { useState } from 'react';
+import { CircleCheck, Newspaper } from 'lucide-react';
+import { Button, ButtonVariant } from '@/atoms/Button/Button';
+import { Container } from '@/atoms/Container/Container';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/atoms/Dialog/Dialog';
+import { Spinner } from '@/atoms/Spinner/Spinner';
+import { Typography } from '@/atoms/Typography/Typography';
+import { BITKIT_APP_STORE_URL, BITKIT_PLAY_STORE_URL } from '@/config/externalLinks';
+import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
+import { DEFAULT_LOCK_TITLE } from '@/libs/post/lockTeaser';
+import { formatSats } from '@/libs/utils/formatSats';
+import { cn, formatPublicKey, withPubkyPrefix } from '@/libs/utils/utils';
+import { AppDownload } from '@/molecules/AppDownload/AppDownload';
+import { PostHeaderUserInfo } from '@/molecules/PostHeaderUserInfo/PostHeaderUserInfo';
+import type { DialogPayToUnlockProps } from './DialogPayToUnlock.types';
+
+const FIELD_LABEL_CLASS = 'text-xs font-medium tracking-widest text-muted-foreground uppercase';
+
+const INSTALL_STEPS = ['Install Bitkit', 'Set up your profile with the same pubky', 'Fund your wallet'];
+const BITKIT_LOGO = { src: '/images/bitkit-logo.svg', alt: 'Bitkit', width: 110 };
+
+function CreatorAvatar({ authorId }: { authorId: string }) {
+  const { profile } = useUserProfile(authorId);
+  const userName = profile?.name ?? formatPublicKey({ key: withPubkyPrefix(authorId) });
+
+  return (
+    <PostHeaderUserInfo userId={authorId} userName={userName} avatarUrl={profile?.avatarUrl} showUserInfo={false} />
+  );
+}
+
+/**
+ * Pay to Unlock modal. Purely presentational — `usePayToUnlock` owns the state machine.
+ *
+ * The primary button is the start of the payment: nothing is submitted before it is pressed, so
+ * opening and closing the modal is always safe. Closing during `waiting` is allowed too — the
+ * purchase lives on the server and the stored bundle id picks it back up on reopen — but it asks
+ * first, because a spinner vanishing on its own reads as a lost payment.
+ */
+export function DialogPayToUnlock({
+  open,
+  onOpenChange,
+  lockTitle,
+  authorId,
+  priceSats,
+  stage,
+  isStalled,
+  isSubmitting,
+  onSubmit,
+  onRecheck,
+  onViewContent,
+}: DialogPayToUnlockProps) {
+  const isInstall = stage === 'install';
+  const showPrimary = stage === 'pay' || stage === 'install';
+  const [isConfirmingClose, setIsConfirmingClose] = useState(false);
+
+  const handleOpenChange = (next: boolean) => {
+    // Paid content is already in memory. Closing should reveal that copy instead of enabling the
+    // background recovery path, which would download the same content again.
+    if (!next && stage === 'paid') {
+      onViewContent();
+      return;
+    }
+    // `isSubmitting` covers the gap before `waiting`: the submission is already in flight while the
+    // body still shows the pay screen, and on a slow connection that lasts seconds.
+    if (!next && (stage === 'waiting' || isSubmitting)) {
+      setIsConfirmingClose(true);
+      return;
+    }
+    onOpenChange(next);
+  };
+
+  const confirmClose = () => {
+    setIsConfirmingClose(false);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="w-full max-w-md rounded-xl border-x-0 border-y border-brand bg-card sm:max-w-xl"
+        // Clicks bubble through the portal to the post card, which would navigate to the post.
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DialogHeader>
+          <DialogTitle>{stage === 'paid' ? 'Unlocked' : 'Pay to Unlock'}</DialogTitle>
+        </DialogHeader>
+
+        <Container overrideDefaults className="flex items-center gap-2 rounded-md bg-muted p-6">
+          <Newspaper className="size-6 shrink-0 text-muted-foreground" aria-hidden />
+          <Typography className="min-w-0 flex-1 truncate text-xl font-bold text-foreground">
+            {lockTitle || DEFAULT_LOCK_TITLE}
+          </Typography>
+          <CreatorAvatar authorId={authorId} />
+        </Container>
+
+        <Container overrideDefaults className="flex items-start gap-6 rounded-md border border-dashed border-input p-6">
+          <Container overrideDefaults className="flex min-w-0 flex-1 flex-col gap-3">
+            <Container overrideDefaults className="flex flex-col gap-1">
+              <Typography className={cn(FIELD_LABEL_CLASS, stage === 'paid' && 'text-brand')}>
+                {stage === 'paid' ? 'PAYMENT RECEIVED' : 'COST TO UNLOCK'}
+              </Typography>
+              <Typography className="text-2xl font-bold text-foreground">
+                {formatSats(priceSats, { space: true })}
+              </Typography>
+            </Container>
+
+            {stage === 'checking' && (
+              <Container overrideDefaults className="flex items-center justify-center py-4">
+                <Spinner size="md" />
+              </Container>
+            )}
+
+            {stage === 'pay' && (
+              <>
+                <Typography className="text-base text-secondary-foreground">
+                  {'Open your Bitkit wallet and pay to unlock.'}
+                </Typography>
+                <AppDownload
+                  logo={BITKIT_LOGO}
+                  appStoreUrl={BITKIT_APP_STORE_URL}
+                  playStoreUrl={BITKIT_PLAY_STORE_URL}
+                  layout="row"
+                />
+              </>
+            )}
+
+            {isInstall && (
+              <>
+                <Container overrideDefaults className="flex flex-col gap-1">
+                  {INSTALL_STEPS.map((step, index) => (
+                    <Typography key={step} className="text-base text-secondary-foreground">
+                      <span className="font-bold">{`${index + 1}) `}</span>
+                      {step}
+                    </Typography>
+                  ))}
+                </Container>
+                <AppDownload
+                  logo={BITKIT_LOGO}
+                  appStoreUrl={BITKIT_APP_STORE_URL}
+                  playStoreUrl={BITKIT_PLAY_STORE_URL}
+                  layout="row"
+                />
+              </>
+            )}
+
+            {stage === 'waiting' && (
+              <Container overrideDefaults className="flex flex-col items-center gap-3 py-4">
+                {/* Parked, not failed: the purchase is alive, so the reader gets a way back to it
+                  rather than a spinner that never resolves. */}
+                {isStalled ? (
+                  <>
+                    <Typography className="text-center text-base text-secondary-foreground">
+                      {'Still waiting for the payment. Pay in Bitkit, then check again.'}
+                    </Typography>
+                    <Button
+                      variant={ButtonVariant.OUTLINE}
+                      size="lg"
+                      onClick={onRecheck}
+                      data-cy="pay-to-unlock-recheck"
+                    >
+                      {'Check again'}
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Spinner size="md" />
+                    <Typography className={FIELD_LABEL_CLASS}>{'AWAITING PAYMENT'}</Typography>
+                  </>
+                )}
+              </Container>
+            )}
+
+            {stage === 'paid' && (
+              <Typography className="text-base text-secondary-foreground">
+                {'Unlocked. Thank you for supporting creators!'}
+              </Typography>
+            )}
+
+            {stage === 'blocked' && (
+              <Typography className="text-base text-secondary-foreground">
+                {'This purchase could not be checked. Close the dialog and try again.'}
+              </Typography>
+            )}
+          </Container>
+
+          {stage === 'paid' && (
+            <Container overrideDefaults className="flex size-24 shrink-0 items-center justify-center" aria-hidden>
+              <CircleCheck className="size-[72px] text-brand" strokeWidth={0.5} />
+            </Container>
+          )}
+        </Container>
+
+        <DialogFooter>
+          {stage === 'paid' ? (
+            <Button
+              variant={ButtonVariant.DEFAULT}
+              size="lg"
+              className="flex-1"
+              onClick={onViewContent}
+              data-cy="pay-to-unlock-view-content"
+            >
+              {'View Content'}
+            </Button>
+          ) : (
+            <Button
+              variant={ButtonVariant.OUTLINE}
+              size="lg"
+              className="flex-1"
+              onClick={() => handleOpenChange(false)}
+              data-cy="pay-to-unlock-cancel"
+            >
+              {/* Past submission there is nothing to cancel — the purchase continues server-side. */}
+              {stage === 'waiting' ? 'Close' : 'Cancel'}
+            </Button>
+          )}
+          {showPrimary && (
+            <Button
+              variant={ButtonVariant.DEFAULT}
+              size="lg"
+              className="flex-1"
+              onClick={onSubmit}
+              disabled={isSubmitting}
+              data-cy="pay-to-unlock-submit"
+            >
+              {isSubmitting ? <Spinner size="sm" /> : isInstall ? 'I completed the steps' : 'Pay with Bitkit'}
+            </Button>
+          )}
+        </DialogFooter>
+
+        {/* Nested inside the parent dialog to avoid mobile touch event issues with sibling portals */}
+        <Dialog open={isConfirmingClose} onOpenChange={setIsConfirmingClose}>
+          <DialogContent className="w-full max-w-md rounded-xl bg-card sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{'The payment is still running'}</DialogTitle>
+            </DialogHeader>
+            <Typography className="text-base text-secondary-foreground">
+              {
+                'Your payment to unlock this post has not finished yet. It keeps running if you close this, and you can open it again to come back to it.'
+              }
+            </Typography>
+            <DialogFooter>
+              <Button
+                variant={ButtonVariant.OUTLINE}
+                size="lg"
+                className="flex-1"
+                onClick={() => setIsConfirmingClose(false)}
+                data-cy="pay-to-unlock-keep-waiting"
+              >
+                {'Keep waiting'}
+              </Button>
+              <Button
+                variant={ButtonVariant.DESTRUCTIVE}
+                size="lg"
+                className="flex-1"
+                onClick={confirmClose}
+                data-cy="pay-to-unlock-close-anyway"
+              >
+                {'Close anyway'}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.tsx
+++ b/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.tsx
@@ -73,6 +73,12 @@ export function DialogPayToUnlock({
 
   const confirmClose = () => {
     setIsConfirmingClose(false);
+    // The payment can finish while this prompt is open. Show the content we already downloaded
+    // instead of throwing it away and downloading it again later.
+    if (stage === 'paid') {
+      onViewContent();
+      return;
+    }
     onOpenChange(false);
   };
 

--- a/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.tsx
+++ b/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.tsx
@@ -53,6 +53,8 @@ export function DialogPayToUnlock({
 }: DialogPayToUnlockProps) {
   const isInstall = stage === 'install';
   const showPrimary = stage === 'pay' || stage === 'install';
+  // `unopened` reached this screen by a completed payment too, so it must not show a cost to pay.
+  const isPaid = stage === 'paid' || stage === 'unopened';
   const [isConfirmingClose, setIsConfirmingClose] = useState(false);
 
   const handleOpenChange = (next: boolean) => {
@@ -104,8 +106,8 @@ export function DialogPayToUnlock({
         <Container overrideDefaults className="flex items-start gap-6 rounded-md border border-dashed border-input p-6">
           <Container overrideDefaults className="flex min-w-0 flex-1 flex-col gap-3">
             <Container overrideDefaults className="flex flex-col gap-1">
-              <Typography className={cn(FIELD_LABEL_CLASS, stage === 'paid' && 'text-brand')}>
-                {stage === 'paid' ? 'PAYMENT RECEIVED' : 'COST TO UNLOCK'}
+              <Typography className={cn(FIELD_LABEL_CLASS, isPaid && 'text-brand')}>
+                {isPaid ? 'PAYMENT RECEIVED' : 'COST TO UNLOCK'}
               </Typography>
               <Typography className="text-2xl font-bold text-foreground">
                 {formatSats(priceSats, { space: true })}
@@ -184,6 +186,17 @@ export function DialogPayToUnlock({
               </Typography>
             )}
 
+            {stage === 'unopened' && (
+              <Container overrideDefaults className="flex flex-col items-center gap-3 py-4">
+                <Typography className="text-center text-base text-secondary-foreground">
+                  {'Payment received. The content could not be opened — nothing is lost.'}
+                </Typography>
+                <Button variant={ButtonVariant.OUTLINE} size="lg" onClick={onRecheck} data-cy="pay-to-unlock-recheck">
+                  {'Check again'}
+                </Button>
+              </Container>
+            )}
+
             {stage === 'blocked' && (
               <Typography className="text-base text-secondary-foreground">
                 {'This purchase could not be checked. Close the dialog and try again.'}
@@ -218,7 +231,7 @@ export function DialogPayToUnlock({
               data-cy="pay-to-unlock-cancel"
             >
               {/* Past submission there is nothing to cancel — the purchase continues server-side. */}
-              {stage === 'waiting' ? 'Close' : 'Cancel'}
+              {stage === 'waiting' || stage === 'unopened' ? 'Close' : 'Cancel'}
             </Button>
           )}
           {showPrimary && (

--- a/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.types.ts
+++ b/src/components/molecules/DialogPayToUnlock/DialogPayToUnlock.types.ts
@@ -1,0 +1,23 @@
+import type { TPayToUnlockStage } from '@/hooks/usePayToUnlock/usePayToUnlock.types';
+
+export interface DialogPayToUnlockProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Creator-typed lock title, shown in the header card. */
+  lockTitle: string;
+  /** Post author — the avatar beside the title links to their profile. */
+  authorId: string;
+  /** Price in sats (wire string), from the lock file's payment criterion. */
+  priceSats: string;
+  stage: TPayToUnlockStage;
+  /** Waiting stage: polling parked on its deadline, so the reader is offered a manual re-check. */
+  isStalled: boolean;
+  /** True while a submission is in flight — locks the primary button. */
+  isSubmitting: boolean;
+  /** Primary action of `pay` and `install`: starts the payment. */
+  onSubmit: () => void;
+  /** Restarts a parked wait. */
+  onRecheck: () => void;
+  /** Reveals the downloaded content from the paid confirmation screen. */
+  onViewContent: () => void;
+}

--- a/src/components/molecules/DialogUnlockContent/DialogUnlockContent.test.tsx
+++ b/src/components/molecules/DialogUnlockContent/DialogUnlockContent.test.tsx
@@ -80,4 +80,18 @@ describe('DialogUnlockContent', () => {
     setup({ error: true });
     expect(screen.getByText(/Couldn't unlock/i)).toBeInTheDocument();
   });
+
+  // The dialog is portaled, but React still bubbles its clicks to the post card, which would navigate.
+  it('clicks inside the dialog do not reach the post card', () => {
+    const cardClick = vi.fn();
+    render(
+      <div onClick={cardClick}>
+        <DialogUnlockContent open onOpenChange={vi.fn()} lockTitle="Private Key Management" onSubmit={vi.fn()} />
+      </div>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Password', { selector: 'input' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(cardClick).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/molecules/DialogUnlockContent/DialogUnlockContent.tsx
+++ b/src/components/molecules/DialogUnlockContent/DialogUnlockContent.tsx
@@ -46,7 +46,11 @@ export function DialogUnlockContent({
 
   return (
     <Dialog open={open} onOpenChange={close}>
-      <DialogContent className="w-full max-w-md rounded-xl border-x-0 border-y border-brand bg-card sm:max-w-xl">
+      <DialogContent
+        className="w-full max-w-md rounded-xl border-x-0 border-y border-brand bg-card sm:max-w-xl"
+        // Clicks bubble through the portal to the post card, which would navigate to the post.
+        onClick={(e) => e.stopPropagation()}
+      >
         <DialogHeader>
           <DialogTitle>{'Password to Unlock'}</DialogTitle>
         </DialogHeader>
@@ -76,7 +80,7 @@ export function DialogUnlockContent({
           />
           {error && (
             <Typography size="sm" className="text-destructive">
-              {'Couldn\'t unlock this content. Please try again.'}
+              {"Couldn't unlock this content. Please try again."}
             </Typography>
           )}
         </form>

--- a/src/components/molecules/LockedPostCard/LockedPostCard.tsx
+++ b/src/components/molecules/LockedPostCard/LockedPostCard.tsx
@@ -6,6 +6,7 @@ import type { TLockConfig } from '@/application/locks/locks.types';
 import { Button, ButtonVariant } from '@/atoms/Button/Button';
 import { Image } from '@/atoms/Image/Image';
 import { DEFAULT_LOCK_TITLE } from '@/libs/post/lockTeaser';
+import { formatSats } from '@/libs/utils/formatSats';
 import { cn } from '@/libs/utils/utils';
 
 interface LockedPostCardProps {
@@ -29,8 +30,6 @@ interface LockedPostCardProps {
 /** Stands in for an unlock requirement the reader can't be shown — a password, or an unresolved lock. */
 const HIDDEN_REQUIREMENT_MASK = '••••••';
 
-const satsFormatter = new Intl.NumberFormat('en-US');
-
 /** Slide-over duration — the single source for both the CSS transition and the deferred modal open.
  *  Exported for tests (they advance fake timers by exactly this). */
 export const SLIDE_MS = 200;
@@ -48,9 +47,7 @@ export function LockedPostCard({
   const isDisabled = disabled ?? !onUnlock;
   const UnlockInfoIcon = unlockInfo?.method === 'payment' ? Wallet : Shield;
   const unlockInfoLabel =
-    unlockInfo?.method === 'payment'
-      ? `₿${satsFormatter.format(Number(unlockInfo.amountSats))}`
-      : HIDDEN_REQUIREMENT_MASK;
+    unlockInfo?.method === 'payment' ? formatSats(unlockInfo.amountSats) : HIDDEN_REQUIREMENT_MASK;
 
   const buttonRef = useRef<HTMLButtonElement>(null);
   const lockInfoRef = useRef<HTMLDivElement>(null);

--- a/src/components/molecules/LockedPostCard/LockedPostCard.tsx
+++ b/src/components/molecules/LockedPostCard/LockedPostCard.tsx
@@ -17,6 +17,12 @@ interface LockedPostCardProps {
   onUnlock?: () => void;
   /** Whether the unlock modal is open. Keeps the slid-over button parked until the modal closes. */
   unlockOpen?: boolean;
+  /**
+   * Whether pressing Unlock opens the unlock modal. False runs `onUnlock` straight away without the
+   * slide-over — only a modal closing snaps the button back, so a click that opens something else
+   * (sign-in) would leave it parked over the price for good.
+   */
+  slideOnUnlock?: boolean;
   /** Force the Unlock control disabled. Defaults to `!onUnlock` (inert without a handler). */
   disabled?: boolean;
   /**
@@ -40,6 +46,7 @@ export function LockedPostCard({
   unlockInfo,
   onUnlock,
   unlockOpen,
+  slideOnUnlock = true,
   disabled,
   editableTitle,
   className,
@@ -71,6 +78,10 @@ export function LockedPostCard({
     event.stopPropagation();
     // The ref guard also blocks a double-click: a second click during the slide is a no-op.
     if (isDisabled || slideTimer.current !== null) return;
+    if (!slideOnUnlock) {
+      onUnlock?.();
+      return;
+    }
 
     const button = buttonRef.current;
     const lockInfo = lockInfoRef.current;

--- a/src/components/organisms/DialogLocksAuth/DialogLocksAuth.tsx
+++ b/src/components/organisms/DialogLocksAuth/DialogLocksAuth.tsx
@@ -27,19 +27,14 @@ import {
   DialogTitle,
 } from '@/atoms/Dialog/Dialog';
 import { Image } from '@/atoms/Image/Image';
-import { Link } from '@/atoms/Link/Link';
 import { Typography } from '@/atoms/Typography/Typography';
-import {
-  BITKIT_APP_STORE_URL,
-  BITKIT_PLAY_STORE_URL,
-  getAppStoreLink,
-  getPlayStoreLink,
-} from '@/config/externalLinks';
+import { BITKIT_APP_STORE_URL, BITKIT_PLAY_STORE_URL, getAppStoreLink, getPlayStoreLink } from '@/config/externalLinks';
 import { useLocksAuthFlow } from '@/hooks/useLocksAuthFlow/useLocksAuthFlow';
 import { LocksAuthFlowStatus } from '@/hooks/useLocksAuthFlow/useLocksAuthFlow.types';
 import { usePaykitSetupFlow } from '@/hooks/usePaykitSetupFlow/usePaykitSetupFlow';
 import { PaykitSetupFlowStatus } from '@/hooks/usePaykitSetupFlow/usePaykitSetupFlow.types';
 import { cn } from '@/libs/utils/utils';
+import { AppDownload } from '@/molecules/AppDownload/AppDownload';
 import { isLocksAuthenticated as isLocksAuthenticatedState } from '@/stores/locksAuth/locksAuth.selectors';
 import { useLocksAuthStore } from '@/stores/locksAuth/locksAuth.store';
 
@@ -59,31 +54,6 @@ function StepImage({ src, alt }: { src: string; alt: string }) {
   return (
     <Container className="flex items-center justify-center px-12 py-6">
       <Image src={src} alt={alt} width={192} height={192} className="size-48" />
-    </Container>
-  );
-}
-
-/** Wordmark + store badges under a step's QR. */
-function AppDownload({
-  logo,
-  appStoreUrl,
-  playStoreUrl,
-}: {
-  logo: { src: string; alt: string; width: number };
-  appStoreUrl: string;
-  playStoreUrl: string;
-}) {
-  return (
-    <Container className="flex flex-col items-center gap-4">
-      <Image src={logo.src} alt={logo.alt} width={logo.width} height={32} />
-      <Container className="flex flex-row items-center justify-center gap-3.5">
-        <Link href={appStoreUrl} target="_blank">
-          <Image src="/images/badge-apple.webp" alt="App Store" width={72} height={24} />
-        </Link>
-        <Link href={playStoreUrl} target="_blank">
-          <Image src="/images/badge-android.webp" alt="Google Play" width={81} height={24} />
-        </Link>
-      </Container>
     </Container>
   );
 }

--- a/src/components/organisms/LockedPostContent/LockedPostContent.test.tsx
+++ b/src/components/organisms/LockedPostContent/LockedPostContent.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LocksController } from '@/controllers/locks/locks';
 import { useLockFile } from '@/hooks/useLockFile/useLockFile';
@@ -12,6 +12,62 @@ import { LockedPostContent } from './LockedPostContent';
 const { toastMock } = vi.hoisted(() => ({ toastMock: vi.fn() }));
 
 vi.mock('@/hooks/useLockFile/useLockFile', () => ({ useLockFile: vi.fn() }));
+// The pay hook has its own tests; here only the wiring matters. `payMocks.params` captures what the
+// component passed so a test can drive `onCompleted` as if the payment finished.
+type PayParams = { open: boolean; onPurchased: (lockId: string) => void; onCompleted: (content: unknown) => void };
+const payMocks = vi.hoisted(() => ({
+  params: null as null | PayParams,
+  submit: vi.fn(),
+  viewContent: vi.fn(),
+  requireAuth: vi.fn((action: () => unknown) => action()),
+}));
+vi.mock('@/hooks/usePayToUnlock/usePayToUnlock', () => ({
+  usePayToUnlock: (params: PayParams) => {
+    payMocks.params = params;
+    return { stage: 'pay', isSubmitting: false, submit: payMocks.submit, viewContent: payMocks.viewContent };
+  },
+}));
+// 'lock1' is the id in LOCK_URL, so the payment-lock tests start from an already purchased lock.
+const purchasedMocks = vi.hoisted(() => ({
+  params: null as null | { enabled: boolean },
+  hasPurchase: vi.fn((lockId: string | null) => lockId === 'lock1'),
+  markPurchased: vi.fn(),
+}));
+vi.mock('@/hooks/usePurchasedLocks/usePurchasedLocks', () => ({
+  usePurchasedLocks: (params: { enabled: boolean }) => {
+    purchasedMocks.params = params;
+    return { hasPurchase: purchasedMocks.hasPurchase, markPurchased: purchasedMocks.markPurchased };
+  },
+}));
+// The resume hook has its own tests; here only the wiring matters — capture what it was handed.
+const resumeMocks = vi.hoisted(() => ({
+  params: null as null | { onResumed: (content: unknown) => void; isPurchased: boolean; hasContent: boolean },
+}));
+vi.mock('@/hooks/usePurchaseResume/usePurchaseResume', () => ({
+  usePurchaseResume: (params: { onResumed: (content: unknown) => void; isPurchased: boolean; hasContent: boolean }) => {
+    resumeMocks.params = params;
+  },
+}));
+vi.mock('@/hooks/useRequireAuth/useRequireAuth', () => ({
+  useRequireAuth: () => ({ isAuthenticated: true, requireAuth: payMocks.requireAuth }),
+}));
+vi.mock('@/molecules/DialogPayToUnlock/DialogPayToUnlock', () => ({
+  DialogPayToUnlock: ({
+    open,
+    priceSats,
+    onViewContent,
+  }: {
+    open: boolean;
+    priceSats: string;
+    onViewContent: () => void;
+  }) =>
+    open ? (
+      <div data-testid="pay-dialog">
+        {priceSats}
+        <button onClick={onViewContent}>{'Mock view content'}</button>
+      </div>
+    ) : null,
+}));
 vi.mock('@/controllers/locks/locks', () => ({
   LocksController: {
     getLockContent: vi.fn(),
@@ -59,6 +115,9 @@ describe('LockedPostContent', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     toastMock.mockClear();
+    purchasedMocks.hasPurchase.mockReset(); // back to the `lock1` implementation
+    purchasedMocks.markPurchased.mockClear();
+    payMocks.viewContent.mockClear();
     vi.mocked(LocksController.fetchReplicatedContent).mockResolvedValue(null);
     vi.mocked(LocksController.replicateUnlockedContent).mockResolvedValue(undefined);
   });
@@ -90,6 +149,111 @@ describe('LockedPostContent', () => {
     mockLockData({ lockFile: null, priceSats: null });
     render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
     expect(screen.getByText('••••••')).toBeInTheDocument();
+  });
+
+  describe('payment lock', () => {
+    const paymentData = () =>
+      mockLockData({ lockFile: asOpaque<LockFile>({ creator: 'pubkybob' }), priceSats: '1000' });
+
+    it('opens the pay dialog (behind the auth gate) instead of the password dialog', async () => {
+      paymentData();
+      render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Unlock' }));
+      // The card defers onUnlock until its slide-over finishes; findBy waits that out.
+      expect(await screen.findByTestId('pay-dialog')).toHaveTextContent('1000');
+      expect(payMocks.requireAuth).toHaveBeenCalled();
+      expect(screen.queryByRole('heading', { name: 'Password to Unlock' })).not.toBeInTheDocument();
+    });
+
+    // Paid while away: the content arrives without the reader pressing anything.
+    it('renders content recovered by the resume hook, with no interaction', async () => {
+      paymentData();
+      render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
+
+      expect(resumeMocks.params?.hasContent).toBe(false);
+
+      act(() =>
+        resumeMocks.params?.onResumed({
+          post: { content: 'recovered secret', kind: 'short', attachments: null },
+          attachments: [],
+        }),
+      );
+
+      await waitFor(() => expect(screen.getByText('recovered secret')).toBeInTheDocument());
+      expect(screen.queryByTestId('pay-dialog')).not.toBeInTheDocument();
+      // Purchase entries outlive the replica, so once the content is on screen the hook has to be
+      // told — otherwise an old unlock is re-downloaded and re-replicated on every mount.
+      expect(resumeMocks.params?.hasContent).toBe(true);
+    });
+
+    // A password-only feed must never read the purchases directory.
+    it('enables the purchase listing only for payment locks', () => {
+      paymentData();
+      render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
+      expect(purchasedMocks.params?.enabled).toBe(true);
+
+      mockLockData({ lockFile: asOpaque<LockFile>({ creator: 'pubkybob' }) });
+      render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
+      expect(purchasedMocks.params?.enabled).toBe(false);
+    });
+
+    it('tells the recovery hook the lock is purchased from the listing', () => {
+      paymentData();
+      render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
+      expect(resumeMocks.params?.isPurchased).toBe(true);
+
+      purchasedMocks.hasPurchase.mockReturnValue(false);
+      render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
+      expect(resumeMocks.params?.isPurchased).toBe(false);
+    });
+
+    it('leaves purchase recovery to the pay hook while its dialog is open', async () => {
+      paymentData();
+      render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
+      expect(resumeMocks.params?.isPurchased).toBe(true);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Unlock' }));
+      await screen.findByTestId('pay-dialog');
+
+      expect(resumeMocks.params?.isPurchased).toBe(false);
+    });
+
+    it('records a new purchase in the session listing', () => {
+      paymentData();
+      render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
+
+      payMocks.params?.onPurchased('lock1');
+      expect(purchasedMocks.markPurchased).toHaveBeenCalledWith('lock1');
+    });
+
+    it('connects the pay dialog view action to the pay hook', async () => {
+      paymentData();
+      render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Unlock' }));
+      await screen.findByTestId('pay-dialog');
+      fireEvent.click(screen.getByRole('button', { name: 'Mock view content' }));
+
+      expect(payMocks.viewContent).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the unlocked content once the payment completes', async () => {
+      paymentData();
+      render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Unlock' }));
+      await screen.findByTestId('pay-dialog');
+      act(() =>
+        payMocks.params?.onCompleted({
+          post: { content: 'the paid secret', kind: 'short', attachments: null },
+          attachments: [],
+        }),
+      );
+
+      await waitFor(() => expect(screen.getByText('the paid secret')).toBeInTheDocument());
+      expect(screen.queryByTestId('pay-dialog')).not.toBeInTheDocument(); // closed on success
+    });
   });
 
   it('renders nothing when the teaser content is unparseable', () => {

--- a/src/components/organisms/LockedPostContent/LockedPostContent.test.tsx
+++ b/src/components/organisms/LockedPostContent/LockedPostContent.test.tsx
@@ -19,8 +19,19 @@ const payMocks = vi.hoisted(() => ({
   params: null as null | PayParams,
   submit: vi.fn(),
   viewContent: vi.fn(),
-  requireAuth: vi.fn((action: () => unknown) => action()),
 }));
+const authMocks = vi.hoisted(() => {
+  const mocks = {
+    isAuthenticated: true,
+    setShowSignInDialog: vi.fn(),
+    requireAuth: vi.fn((action: () => unknown) => {
+      if (mocks.isAuthenticated) return action();
+      mocks.setShowSignInDialog(true);
+      return undefined;
+    }),
+  };
+  return mocks;
+});
 vi.mock('@/hooks/usePayToUnlock/usePayToUnlock', () => ({
   usePayToUnlock: (params: PayParams) => {
     payMocks.params = params;
@@ -49,7 +60,7 @@ vi.mock('@/hooks/usePurchaseResume/usePurchaseResume', () => ({
   },
 }));
 vi.mock('@/hooks/useRequireAuth/useRequireAuth', () => ({
-  useRequireAuth: () => ({ isAuthenticated: true, requireAuth: payMocks.requireAuth }),
+  useRequireAuth: () => ({ isAuthenticated: authMocks.isAuthenticated, requireAuth: authMocks.requireAuth }),
 }));
 vi.mock('@/molecules/DialogPayToUnlock/DialogPayToUnlock', () => ({
   DialogPayToUnlock: ({
@@ -111,6 +122,20 @@ const mockLockData = ({
 
 const LOCK_URL = 'pubky://hs/pub/locks.app/lock1.json';
 
+/** jsdom reports every offset as 0, which would make the slide-over a no-op no test could see. */
+const useSlideGeometry = () => {
+  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetLeft');
+  Object.defineProperty(HTMLElement.prototype, 'offsetLeft', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return this.tagName === 'BUTTON' ? 0 : 120;
+    },
+  });
+  return () => {
+    if (original) Object.defineProperty(HTMLElement.prototype, 'offsetLeft', original);
+  };
+};
+
 describe('LockedPostContent', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -118,6 +143,9 @@ describe('LockedPostContent', () => {
     purchasedMocks.hasPurchase.mockReset(); // back to the `lock1` implementation
     purchasedMocks.markPurchased.mockClear();
     payMocks.viewContent.mockClear();
+    authMocks.isAuthenticated = true;
+    authMocks.requireAuth.mockClear();
+    authMocks.setShowSignInDialog.mockClear();
     vi.mocked(LocksController.fetchReplicatedContent).mockResolvedValue(null);
     vi.mocked(LocksController.replicateUnlockedContent).mockResolvedValue(undefined);
   });
@@ -162,8 +190,27 @@ describe('LockedPostContent', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Unlock' }));
       // The card defers onUnlock until its slide-over finishes; findBy waits that out.
       expect(await screen.findByTestId('pay-dialog')).toHaveTextContent('1000');
-      expect(payMocks.requireAuth).toHaveBeenCalled();
+      expect(authMocks.requireAuth).toHaveBeenCalled();
       expect(screen.queryByRole('heading', { name: 'Password to Unlock' })).not.toBeInTheDocument();
+    });
+
+    // Signed out, Unlock opens the sign-in dialog and no unlock modal follows — so the card never
+    // gets the close that snaps the slid-over button back, and it would sit over the price for good.
+    it('leaves the Unlock button in place for a signed-out reader', async () => {
+      const restoreGeometry = useSlideGeometry();
+      try {
+        authMocks.isAuthenticated = false;
+        paymentData();
+        render(<LockedPostContent content="{}" lock={LOCK_URL} authorId="pubkycreator" />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Unlock' }));
+        await waitFor(() => expect(authMocks.setShowSignInDialog).toHaveBeenCalledWith(true));
+
+        expect(screen.queryByTestId('pay-dialog')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Unlock' })).toHaveStyle({ transform: 'translateX(0px)' });
+      } finally {
+        restoreGeometry();
+      }
     });
 
     // Paid while away: the content arrives without the reader pressing anything.

--- a/src/components/organisms/LockedPostContent/LockedPostContent.tsx
+++ b/src/components/organisms/LockedPostContent/LockedPostContent.tsx
@@ -6,14 +6,21 @@ import type { TLockConfig } from '@/application/locks/locks.types';
 import { Container } from '@/atoms/Container/Container';
 import { LocksController } from '@/controllers/locks/locks';
 import { useLockFile } from '@/hooks/useLockFile/useLockFile';
+import { usePayToUnlock } from '@/hooks/usePayToUnlock/usePayToUnlock';
+import { usePurchasedLocks } from '@/hooks/usePurchasedLocks/usePurchasedLocks';
+import { usePurchaseResume } from '@/hooks/usePurchaseResume/usePurchaseResume';
+import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
 import { useUnlockedContent } from '@/hooks/useUnlockedContent/useUnlockedContent';
 import { isArticleContent } from '@/libs/post/articleContent';
 import { cn } from '@/libs/utils/utils';
 import type { PostDetailsModel } from '@/models/post/details/postDetails';
+import { DialogPayToUnlock } from '@/molecules/DialogPayToUnlock/DialogPayToUnlock';
 import { DialogUnlockContent } from '@/molecules/DialogUnlockContent/DialogUnlockContent';
 import { LockedPostCard } from '@/molecules/LockedPostCard/LockedPostCard';
 import { toast } from '@/molecules/Toaster/toast';
 import type { AttachmentConstructed } from '@/organisms/PostAttachments/PostAttachments.types';
+import { LockContentParser } from '@/pipes/locks/locks.parser';
+import type { TUnlockedContent } from '@/services/locks/locks.types';
 import { PostArticle } from '../PostArticle/PostArticle';
 import { PostBody } from '../PostBody/PostBody';
 
@@ -44,6 +51,7 @@ export function LockedPostContent({
   textClassName,
 }: LockedPostContentProps) {
   const [isUnlockOpen, setIsUnlockOpen] = useState(false);
+  const [isPayOpen, setIsPayOpen] = useState(false);
   const [isUnlocking, setIsUnlocking] = useState(false);
   const [unlockError, setUnlockError] = useState(false);
   const lockContent = LocksController.getLockContent(content);
@@ -54,26 +62,73 @@ export function LockedPostContent({
     : priceSats
       ? { method: 'payment', amountSats: priceSats }
       : { method: 'password' };
-  const { unlockedPost, applyUnlockedContent, media, isOwnLock } = useUnlockedContent({ lock, lockFile, authorId });
+  const { unlockedPost, applyUnlockedContent, media, isOwnLock, isResolvingReplica } = useUnlockedContent({
+    lock,
+    lockFile,
+    authorId,
+  });
+  const { requireAuth } = useRequireAuth();
+  const isPaymentLock = unlockInfo?.method === 'payment';
+
+  /** Renders unlocked content, closes whichever dialog produced it, and reports dropped media. */
+  const showUnlockedContent = (unlocked: TUnlockedContent) => {
+    setIsUnlockOpen(false);
+    setIsPayOpen(false);
+
+    applyUnlockedContent(unlocked); // renders + replicates into the reader's /priv
+    // A dropped attachment is a permanent data error already reported to Sentry. Warn the reader
+    // with a toast, but keep rendering the rest of the post — don't block the unlocked view.
+    if (unlocked.attachments.length < (unlocked.post.attachments?.length ?? 0)) {
+      toast({ variant: 'error', description: 'Could not load attachments' });
+    }
+  };
+
+  // Paid but never received: the payment completed while the reader was away, so nothing on screen
+  // would otherwise say so. Resolves itself, without the reader pressing anything.
+  const { hasPurchase, markPurchased } = usePurchasedLocks({ enabled: isPaymentLock });
+  const lockId = lock ? LockContentParser.lockIdFromUrl(lock) : null;
+  usePurchaseResume({
+    lock,
+    lockFile,
+    // The open modal owns status polling and completion. In particular, markPurchased must not
+    // start a competing background finish immediately after a new payment is submitted.
+    isPurchased: !isPayOpen && hasPurchase(lockId),
+    hasContent: Boolean(unlockedPost),
+    isResolvingContent: isResolvingReplica,
+    onResumed: showUnlockedContent,
+  });
+
+  const { stage, isStalled, isSubmitting, submit, recheck, viewContent } = usePayToUnlock({
+    open: isPayOpen,
+    lockUrl: lock ?? '',
+    lockFile,
+    onPurchased: markPurchased,
+    onCompleted: showUnlockedContent,
+  });
 
   if (!lockContent) return null;
 
+  // No lock file (still loading, or its fetch failed) → nothing to unlock against.
+  const handleUnlock = !lockFile
+    ? undefined
+    : isPaymentLock
+      ? // Paying needs the reader's pubky (it is the payment-request delivery address),
+        // so a signed-out reader gets the sign-in dialog instead.
+        () => requireAuth(() => setIsPayOpen(true))
+      : () => {
+          setUnlockError(false); // clear a prior failure so reopening starts clean
+          setIsUnlockOpen(true);
+        };
+
+  // TODO:[Locks] #2369 — the password path (this handler + DialogUnlockContent below) goes away.
   const handleViewContent = async (password: string) => {
     if (!lockFile || !lock) return;
     setIsUnlocking(true);
     setUnlockError(false);
     try {
       const { credential } = await LocksController.unlock({ lockFile, lockUrl: lock, password });
-      // Throws (caught below → error shown, dialog stays open) if the guarded post is unparseable.
-      const content = await LocksController.fetchUnlockedContent({ lockFile, credential });
-      setIsUnlockOpen(false);
-
-      applyUnlockedContent(content); // renders + replicates into the reader's /priv
-      // A dropped attachment is a permanent data error already reported to Sentry. Warn the reader
-      // with a toast, but keep rendering the rest of the post — don't block the unlocked view.
-      if (content.attachments.length < (content.post.attachments?.length ?? 0)) {
-        toast({ variant: 'error', description: 'Could not load attachments' });
-      }
+      // Throws if the guarded post is unparseable; the catch below keeps the dialog open.
+      showUnlockedContent(await LocksController.fetchUnlockedContent({ lockFile, credential }));
     } catch {
       setUnlockError(true); // already logged by the Err factory
     } finally {
@@ -119,19 +174,11 @@ export function LockedPostContent({
           </div>
         </>
       ) : (
-        // No lock file (still loading, or its fetch failed) → nothing to unlock against.
         <LockedPostCard
           title={lockContent.lock_title}
           unlockInfo={unlockInfo}
-          unlockOpen={isUnlockOpen}
-          onUnlock={
-            !lockFile
-              ? undefined
-              : () => {
-                  setUnlockError(false); // clear a prior failure so reopening starts clean
-                  setIsUnlockOpen(true);
-                }
-          }
+          unlockOpen={isUnlockOpen || isPayOpen}
+          onUnlock={handleUnlock}
         />
       )}
       <DialogUnlockContent
@@ -142,6 +189,21 @@ export function LockedPostContent({
         loading={isUnlocking}
         error={unlockError}
       />
+      {isPaymentLock && priceSats && (
+        <DialogPayToUnlock
+          open={isPayOpen}
+          onOpenChange={setIsPayOpen}
+          lockTitle={lockContent.lock_title}
+          authorId={authorId}
+          priceSats={priceSats}
+          stage={stage}
+          isStalled={isStalled}
+          isSubmitting={isSubmitting}
+          onSubmit={submit}
+          onRecheck={recheck}
+          onViewContent={viewContent}
+        />
+      )}
     </Container>
   );
 }

--- a/src/components/organisms/LockedPostContent/LockedPostContent.tsx
+++ b/src/components/organisms/LockedPostContent/LockedPostContent.tsx
@@ -67,7 +67,7 @@ export function LockedPostContent({
     lockFile,
     authorId,
   });
-  const { requireAuth } = useRequireAuth();
+  const { requireAuth, isAuthenticated } = useRequireAuth();
   const isPaymentLock = unlockInfo?.method === 'payment';
 
   /** Renders unlocked content, closes whichever dialog produced it, and reports dropped media. */
@@ -179,6 +179,9 @@ export function LockedPostContent({
           unlockInfo={unlockInfo}
           unlockOpen={isUnlockOpen || isPayOpen}
           onUnlock={handleUnlock}
+          // A signed-out reader gets the sign-in dialog instead of the pay modal, and only a modal
+          // closing snaps the button back.
+          slideOnUnlock={!isPaymentLock || isAuthenticated}
         />
       )}
       <DialogUnlockContent

--- a/src/core/application/locks/locks.test.ts
+++ b/src/core/application/locks/locks.test.ts
@@ -3,6 +3,7 @@ import { ClientErrorCode, ServerErrorCode, ValidationErrorCode } from '@/libs/er
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';
 import { Logger } from '@/libs/logger/logger';
+import { GuardedContentParser } from '@/pipes/locks/locks.parser';
 import type { LockFile, ReplicatedPost, TGuardedResource, TUnlockedContent } from '@/services/locks/locks.types';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { LocksApplication } from './locks';
@@ -13,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   randomUUID: vi.fn(),
   generateBundleId: vi.fn(),
   submitProofBundle: vi.fn(),
+  submitProof: vi.fn(),
   lookupVerificationTask: vi.fn(),
   issueAccessCredential: vi.fn(),
   readContentLock: vi.fn(),
@@ -38,6 +40,7 @@ vi.mock('@/services/locks/locks', () => ({
     createContentLock: mocks.createContentLock,
     generateBundleId: mocks.generateBundleId,
     submitProofBundle: mocks.submitProofBundle,
+    submitProof: mocks.submitProof,
     lookupVerificationTask: mocks.lookupVerificationTask,
     issueAccessCredential: mocks.issueAccessCredential,
     readContentLock: mocks.readContentLock,
@@ -263,6 +266,288 @@ describe('LocksApplication (reader unlock)', () => {
       expect(mocks.issueAccessCredential).not.toHaveBeenCalled();
     },
   );
+});
+
+describe('LocksApplication (payment unlock)', () => {
+  const lockFile = asOpaque<LockFile>({
+    creator: 'pubkybob',
+    criteria: [{ criterion_id: 'criterion-1', verifier_type: 'paykit-payment', params: { amount: '1000' } }],
+  });
+  const lockUrl = 'pubky://pubkybob/pub/locks.app/LOCK1.json';
+  const purchaseUrl = 'pubky://reader1/priv/social/purchases/LOCK1.json';
+  const purchaseBytes = (raw: string) => ({ bytes: new TextEncoder().encode(raw), contentType: 'application/json' });
+  const withPrimary = () =>
+    asOpaque<LockFile>({
+      creator: 'pubkybob',
+      secondary_resources: {},
+      primary_resource: {
+        path: '/priv/locks.app/content/a.json',
+        hash: 'h',
+        content_type: 'application/json',
+        size: 1,
+      },
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('fetchPurchaseBundleId', () => {
+    it('returns null when there is no purchase file', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(null);
+      await expect(LocksApplication.fetchPurchaseBundleId({ lockUrl, readerPubky: 'reader1' })).resolves.toBeNull();
+      expect(mocks.getBytesIfExists).toHaveBeenCalledWith(purchaseUrl);
+    });
+
+    it('returns the stored bundle id', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(purchaseBytes('{"bundle_id":"bundle-1"}'));
+      await expect(LocksApplication.fetchPurchaseBundleId({ lockUrl, readerPubky: 'reader1' })).resolves.toBe(
+        'bundle-1',
+      );
+    });
+
+    // Fail closed: something was purchased and its handle is gone — minting a fresh id could pay twice.
+    it('throws on an unreadable purchase file instead of pretending there is none', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(purchaseBytes('garbage'));
+      await expect(LocksApplication.fetchPurchaseBundleId({ lockUrl, readerPubky: 'reader1' })).rejects.toMatchObject({
+        code: ValidationErrorCode.INVALID_INPUT,
+        operation: 'fetchPurchaseBundleId',
+      });
+    });
+  });
+
+  describe('startPayment', () => {
+    const params = { lockFile, lockUrl, readerPubky: 'reader1', rejectBundleId: null };
+
+    beforeEach(() => {
+      mocks.generateBundleId.mockResolvedValue('fresh-1');
+      mocks.putBlob.mockResolvedValue(undefined);
+      mocks.submitProof.mockResolvedValue({ status: 'pending' });
+    });
+
+    it('mints a bundle id, saves it BEFORE submitting, and returns it with the status', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(null);
+
+      await expect(LocksApplication.startPayment(params)).resolves.toEqual({ bundleId: 'fresh-1', status: 'pending' });
+
+      // The bytes matter, not just the URL: a file written with the wrong id is money nobody can
+      // reach again.
+      const [{ url, blob }] = mocks.putBlob.mock.calls[0] as [{ url: string; blob: Uint8Array }];
+      expect(url).toBe(purchaseUrl);
+      expect(GuardedContentParser.parsePurchaseFile(blob)).toBe('fresh-1');
+      expect(mocks.putBlob.mock.invocationCallOrder[0]).toBeLessThan(mocks.submitProof.mock.invocationCallOrder[0]);
+      expect(mocks.submitProof).toHaveBeenCalledWith({
+        version: 1,
+        bundle_id: 'fresh-1',
+        pubky_lock_resource: 'pubkybob/pub/locks.app/LOCK1.json',
+        reader_public_key: 'pubkyreader1',
+        proofs: [{ criterion_id: 'criterion-1', verifier_type: 'paykit-payment', payload: {} }],
+      });
+    });
+
+    // Another tab (or an earlier press) already saved an id: submit with THAT one. Minting again
+    // would orphan its purchase and pay a second time.
+    it('reuses the saved bundle id without minting or overwriting', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(purchaseBytes('{"bundle_id":"saved-1"}'));
+
+      await expect(LocksApplication.startPayment(params)).resolves.toEqual({ bundleId: 'saved-1', status: 'pending' });
+      expect(mocks.generateBundleId).not.toHaveBeenCalled();
+      expect(mocks.putBlob).not.toHaveBeenCalled();
+      expect(mocks.submitProof).toHaveBeenCalledWith(expect.objectContaining({ bundle_id: 'saved-1' }));
+    });
+
+    // Only the exact rejected id is replaced: another tab may have saved a newer, live one meanwhile.
+    it('keeps a saved id that differs from the rejected one', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(purchaseBytes('{"bundle_id":"saved-1"}'));
+
+      await expect(LocksApplication.startPayment({ ...params, rejectBundleId: 'dead-1' })).resolves.toEqual({
+        bundleId: 'saved-1',
+        status: 'pending',
+      });
+      expect(mocks.generateBundleId).not.toHaveBeenCalled();
+      expect(mocks.putBlob).not.toHaveBeenCalled();
+      expect(mocks.submitProof).toHaveBeenCalledWith(expect.objectContaining({ bundle_id: 'saved-1' }));
+    });
+
+    // failed/expired cannot be retried — the dead id is replaced (file overwritten before submit).
+    it('replaces the rejected bundle id with a fresh one', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(purchaseBytes('{"bundle_id":"dead-1"}'));
+
+      await expect(LocksApplication.startPayment({ ...params, rejectBundleId: 'dead-1' })).resolves.toEqual({
+        bundleId: 'fresh-1',
+        status: 'pending',
+      });
+      expect(mocks.generateBundleId).toHaveBeenCalledTimes(1);
+      expect(mocks.putBlob).toHaveBeenCalledTimes(1);
+      const [{ url, blob }] = mocks.putBlob.mock.calls[0] as [{ url: string; blob: Uint8Array }];
+      expect(url).toBe(purchaseUrl);
+      expect(GuardedContentParser.parsePurchaseFile(blob)).toBe('fresh-1');
+      expect(mocks.putBlob.mock.invocationCallOrder[0]).toBeLessThan(mocks.submitProof.mock.invocationCallOrder[0]);
+      expect(mocks.submitProof).toHaveBeenCalledWith(expect.objectContaining({ bundle_id: 'fresh-1' }));
+    });
+
+    it('does not submit when saving the fresh id fails', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(null);
+      mocks.putBlob.mockRejectedValue(new Error('offline'));
+
+      await expect(LocksApplication.startPayment(params)).rejects.toThrow();
+      expect(mocks.submitProof).not.toHaveBeenCalled();
+    });
+
+    // Fail closed: a saved file that cannot be read means a purchase exists and its id is lost.
+    it('does not mint a replacement for an unreadable saved id', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(purchaseBytes('garbage'));
+
+      await expect(LocksApplication.startPayment(params)).rejects.toMatchObject({
+        code: ValidationErrorCode.INVALID_INPUT,
+        operation: 'fetchPurchaseBundleId',
+      });
+      expect(mocks.generateBundleId).not.toHaveBeenCalled();
+      expect(mocks.submitProof).not.toHaveBeenCalled();
+    });
+
+    // A URL with no lock id must fail before any read or write: there is no file path to save an id under.
+    it.each([
+      [
+        'fetchPurchaseBundleId',
+        (lockUrl: string) => LocksApplication.fetchPurchaseBundleId({ lockUrl, readerPubky: 'reader1' }),
+      ],
+      ['startPayment', (lockUrl: string) => LocksApplication.startPayment({ ...params, lockUrl })],
+    ])('%s rejects a lock URL without a lock id before touching the homeserver', async (_name, call) => {
+      await expect(call('pubky://pubkybob/pub/locks.app/')).rejects.toMatchObject({
+        code: ValidationErrorCode.INVALID_INPUT,
+      });
+      expect(mocks.getBytesIfExists).not.toHaveBeenCalled();
+      expect(mocks.generateBundleId).not.toHaveBeenCalled();
+      expect(mocks.putBlob).not.toHaveBeenCalled();
+      expect(mocks.submitProof).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchPurchasedLockIds', () => {
+    it('lists the reader purchases with one listing', async () => {
+      mocks.listAll.mockResolvedValue([
+        'pubky://reader1/priv/social/purchases/lock1.json',
+        'pubky://reader1/priv/social/purchases/lock2.json',
+      ]);
+
+      await expect(LocksApplication.fetchPurchasedLockIds({ readerPubky: 'reader1' })).resolves.toEqual([
+        'lock1',
+        'lock2',
+      ]);
+      expect(mocks.listAll).toHaveBeenCalledWith({ baseDirectory: 'pubky://reader1/priv/social/purchases/' });
+    });
+  });
+
+  describe('fetchPaidContent', () => {
+    // A fresh credential on every call is what makes an expired one a non-event: nothing is stored
+    // to invalidate, so calling again IS the recovery.
+    it('mints a credential and reads the guarded content with it', async () => {
+      mocks.issueAccessCredential.mockResolvedValue({ credential: 'cred-abc', expires_at: 'e' });
+      mocks.proxyReadGuardedResource.mockResolvedValue(
+        new TextEncoder().encode('{"content":"paid","kind":"short","attachments":null}'),
+      );
+
+      const content = await LocksApplication.fetchPaidContent({ lockFile: withPrimary(), bundleId: 'bundle-1' });
+
+      expect(mocks.issueAccessCredential).toHaveBeenCalledWith('pubkybob', 'bundle-1');
+      expect(mocks.proxyReadGuardedResource).toHaveBeenCalledWith('cred-abc', 'a.json');
+      expect(content.post.content).toBe('paid');
+    });
+
+    // Replication belongs to the caller, which owns the single path that writes a replica.
+    it('does not write the replica itself', async () => {
+      mocks.issueAccessCredential.mockResolvedValue({ credential: 'cred-abc', expires_at: 'e' });
+      mocks.proxyReadGuardedResource.mockResolvedValue(
+        new TextEncoder().encode('{"content":"paid","kind":"short","attachments":null}'),
+      );
+
+      await LocksApplication.fetchPaidContent({ lockFile: withPrimary(), bundleId: 'bundle-1' });
+      expect(mocks.putBlob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchPaymentStatus', () => {
+    it('passes the null through when the submission never reached the server', async () => {
+      mocks.lookupVerificationTask.mockResolvedValue(null);
+      await expect(LocksApplication.fetchPaymentStatus({ lockFile, bundleId: 'bundle-1' })).resolves.toBeNull();
+      expect(mocks.lookupVerificationTask).toHaveBeenCalledWith('pubkybob', 'bundle-1');
+    });
+
+    it('returns only the status of the task the server holds', async () => {
+      mocks.lookupVerificationTask.mockResolvedValue({ status: 'in_progress' });
+      await expect(LocksApplication.fetchPaymentStatus({ lockFile, bundleId: 'bundle-1' })).resolves.toBe(
+        'in_progress',
+      );
+    });
+
+    // Only a 404 means "no task"; an outage shown as null would offer Pay again for a payment that may exist.
+    it('rethrows a non-404 lookup failure', async () => {
+      mocks.lookupVerificationTask.mockRejectedValue(
+        Err.server(ServerErrorCode.SERVICE_UNAVAILABLE, 'down', { service: ErrorService.Locks, operation: 'test' }),
+      );
+
+      await expect(LocksApplication.fetchPaymentStatus({ lockFile, bundleId: 'bundle-1' })).rejects.toMatchObject({
+        code: ServerErrorCode.SERVICE_UNAVAILABLE,
+      });
+    });
+  });
+
+  describe('fetchPaidContentIfCompleted', () => {
+    const params = { lockFile: withPrimary(), lockUrl, readerPubky: 'reader1' };
+    const paidBytes = new TextEncoder().encode('{"content":"paid","kind":"short","attachments":null}');
+
+    it('returns null when the reader has no saved bundle id', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(null);
+
+      await expect(LocksApplication.fetchPaidContentIfCompleted(params)).resolves.toBeNull();
+      expect(mocks.lookupVerificationTask).not.toHaveBeenCalled();
+    });
+
+    // A null here would read as "never paid" and let the caller offer Pay again for a lost purchase.
+    it('propagates an unreadable saved id instead of returning null', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(purchaseBytes('garbage'));
+
+      await expect(LocksApplication.fetchPaidContentIfCompleted(params)).rejects.toMatchObject({
+        code: ValidationErrorCode.INVALID_INPUT,
+      });
+      expect(mocks.lookupVerificationTask).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the server has no task for the saved id', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(purchaseBytes('{"bundle_id":"bundle-1"}'));
+      mocks.lookupVerificationTask.mockResolvedValue(null);
+
+      await expect(LocksApplication.fetchPaidContentIfCompleted(params)).resolves.toBeNull();
+      expect(mocks.issueAccessCredential).not.toHaveBeenCalled();
+      expect(mocks.generateBundleId).not.toHaveBeenCalled();
+      expect(mocks.putBlob).not.toHaveBeenCalled();
+      expect(mocks.submitProof).not.toHaveBeenCalled();
+    });
+
+    // Still pending: the modal owns that wait, so recovery has nothing to do.
+    it('returns null while the payment is not completed', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(purchaseBytes('{"bundle_id":"bundle-1"}'));
+      mocks.lookupVerificationTask.mockResolvedValue({ status: 'pending' });
+
+      await expect(LocksApplication.fetchPaidContentIfCompleted(params)).resolves.toBeNull();
+      expect(mocks.issueAccessCredential).not.toHaveBeenCalled();
+    });
+
+    it('reads the paid content once the payment is completed', async () => {
+      mocks.getBytesIfExists.mockResolvedValue(purchaseBytes('{"bundle_id":"bundle-1"}'));
+      mocks.lookupVerificationTask.mockResolvedValue({ status: 'completed' });
+      mocks.issueAccessCredential.mockResolvedValue({ credential: 'cred-abc', expires_at: 'e' });
+      mocks.proxyReadGuardedResource.mockResolvedValue(paidBytes);
+
+      const content = await LocksApplication.fetchPaidContentIfCompleted(params);
+      expect(content?.post.content).toBe('paid');
+      // Recovery reads; it never buys.
+      expect(mocks.generateBundleId).not.toHaveBeenCalled();
+      expect(mocks.putBlob).not.toHaveBeenCalled();
+      expect(mocks.submitProof).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('LocksApplication.fetchUnlockedContent', () => {

--- a/src/core/application/locks/locks.ts
+++ b/src/core/application/locks/locks.ts
@@ -33,7 +33,12 @@ import type {
   TFetchUnlockedContentParams,
   TFetchUnlockedListParams,
   TLockContentFile,
+  TPaymentBundleParams,
+  TPaymentLockParams,
+  TPurchaseBundleIdParams,
   TReplicateUnlockedContentParams,
+  TStartPaymentParams,
+  TStartPaymentResult,
   TUnlockContentParams,
 } from './locks.types';
 
@@ -80,8 +85,8 @@ export class LocksApplication {
   }
 
   /**
-   * Reader unlock: mint a bundle id, submit the proof, poll until the Lock Server finishes verifying,
-   * then request the access credential.
+   * Password unlock. TODO:[Locks] #2369 deletes this method and its poll constants with the password
+   * UI. Payment locks use `startPayment` → `fetchPaymentStatus` (polled by the modal) → `fetchPaidContent`.
    */
   static async unlockContent({ lockFile, lockUrl, password }: TUnlockContentParams): Promise<TUnlockResult> {
     const { creator } = lockFile;
@@ -93,7 +98,15 @@ export class LocksApplication {
     // Poll the task status until it's no longer verifying (or the attempt ceiling is hit).
     for (let attempt = 0; isVerifying(task.status) && attempt < MAX_POLL_ATTEMPTS; attempt++) {
       await this.wait(POLL_INTERVAL_MS);
-      task = await LocksService.lookupVerificationTask(creator, bundleId);
+      const next = await LocksService.lookupVerificationTask(creator, bundleId);
+      if (!next) {
+        throw Err.server(ServerErrorCode.INVALID_RESPONSE, 'verification task disappeared while polling', {
+          service: ErrorService.Locks,
+          operation: 'unlockContent',
+          context: { bundleId },
+        });
+      }
+      task = next;
     }
 
     if (task.status !== 'completed') {
@@ -115,6 +128,126 @@ export class LocksApplication {
 
     const credential = await LocksService.issueAccessCredential(creator, bundleId);
     return { bundleId, credential: credential.credential, expiresAt: credential.expires_at };
+  }
+
+  /**
+   * Reads `/priv/social/purchases/<lockId>.json` from the reader's own homeserver and returns the
+   * bundle id inside, or null when the file does not exist. A file that exists but cannot be parsed
+   * throws: a purchase was made and its id is lost, so the caller must show an error instead of
+   * offering to pay again with a fresh id, which could charge the reader twice.
+   */
+  static async fetchPurchaseBundleId({ lockUrl, readerPubky }: TPurchaseBundleIdParams): Promise<string | null> {
+    const lockId = this.requireLockId(lockUrl, 'fetchPurchaseBundleId');
+    const stored = await HomeserverService.getBytesIfExists(GuardedContentParser.purchaseUrl(readerPubky, lockId));
+    if (!stored) return null;
+
+    const bundleId = GuardedContentParser.parsePurchaseFile(stored.bytes);
+    if (!bundleId) {
+      throw Err.validation(ValidationErrorCode.INVALID_INPUT, 'purchase bundle id file is unreadable', {
+        service: ErrorService.Locks,
+        operation: 'fetchPurchaseBundleId',
+        context: { lockId },
+      });
+    }
+    return bundleId;
+  }
+
+  /** Whether the reader's wallet has published a Paykit receiver. */
+  static hasPaykitReceiver(readerPubky: string): Promise<boolean> {
+    return LocksService.hasPaykitReceiver(readerPubky);
+  }
+
+  /**
+   * Starts (or restarts) a payment: reuses the bundle id saved on the reader's homeserver, or mints
+   * and saves a fresh one when there is none or the saved one is `rejectBundleId`. Then submits the
+   * proof to the Lock Server, which creates the verification task (or returns the existing one on a
+   * replay of the same id) and has Paykit deliver the payment request to the reader's wallet.
+   */
+  static async startPayment({
+    lockFile,
+    lockUrl,
+    readerPubky,
+    rejectBundleId,
+  }: TStartPaymentParams): Promise<TStartPaymentResult> {
+    // TODO:[Locks] #2468 — the read → mint → write below is not atomic across tabs: two tabs can
+    // both read "no file" and submit different bundle ids (two tasks, possible double charge).
+    let bundleId = await this.fetchPurchaseBundleId({ lockUrl, readerPubky });
+    if (!bundleId || bundleId === rejectBundleId) {
+      bundleId = await LocksService.generateBundleId();
+      // Saved BEFORE the proof is submitted: a submission that succeeds while the file is missing
+      // leaves a purchase nobody can reach.
+      await HomeserverService.putBlob({
+        url: GuardedContentParser.purchaseUrl(readerPubky, this.requireLockId(lockUrl, 'startPayment')),
+        blob: new TextEncoder().encode(GuardedContentParser.buildPurchaseFile(bundleId)),
+      });
+    }
+    const bundle = LockProofBundler.buildPayment(lockFile, lockUrl, bundleId, readerPubky);
+    const task = await LocksService.submitProof(bundle);
+    return { bundleId, status: task.status };
+  }
+
+  /**
+   * One read of where the Lock Server's payment verification stands for a saved bundle id, or null
+   * when the submission never reached the server — the caller then offers Pay again with that id.
+   */
+  static async fetchPaymentStatus({ lockFile, bundleId }: TPaymentBundleParams): Promise<TVerificationStatus | null> {
+    const task = await LocksService.lookupVerificationTask(lockFile.creator, bundleId);
+    return task?.status ?? null;
+  }
+
+  /**
+   * Lock ids the reader has started a payment for, from `/priv/social/purchases/`. The bundle id
+   * file is written before the proof is submitted, so pending and failed purchases are included.
+   * One listing answers it for every lock post on screen, so the feed never asks per post.
+   */
+  static async fetchPurchasedLockIds({ readerPubky }: TFetchUnlockedListParams): Promise<string[]> {
+    const files = await HomeserverService.listAll({
+      baseDirectory: GuardedContentParser.purchasesRootUrl(readerPubky),
+    });
+    return GuardedContentParser.purchasedLockIds(files);
+  }
+
+  /**
+   * Gets an access credential for a paid bundle id from the Lock Server, then downloads the post
+   * and attachments with it. Replication stays with the caller, which owns the one path that
+   * writes it.
+   *
+   * The credential is short-lived and never stored, so an expired one is not a state to detect:
+   * this mints a new one on every call, and a mid-read expiry is answered by calling again.
+   */
+  static async fetchPaidContent({ lockFile, bundleId }: TPaymentBundleParams): Promise<TUnlockedContent> {
+    const { credential } = await LocksService.issueAccessCredential(lockFile.creator, bundleId);
+    return this.fetchUnlockedContent({ lockFile, credential });
+  }
+
+  /**
+   * `fetchPaidContent` for a caller that knows neither the bundle id nor whether the payment went
+   * through: looks up the saved id, checks the verification status, and downloads only when it is
+   * `completed`; null otherwise. Read-only; never mints an id or submits a proof.
+   */
+  static async fetchPaidContentIfCompleted({
+    lockFile,
+    lockUrl,
+    readerPubky,
+  }: TPaymentLockParams): Promise<TUnlockedContent | null> {
+    const bundleId = await this.fetchPurchaseBundleId({ lockUrl, readerPubky });
+    if (!bundleId) return null;
+    const status = await this.fetchPaymentStatus({ lockFile, bundleId });
+    if (status !== 'completed') return null;
+    return this.fetchPaidContent({ lockFile, bundleId });
+  }
+
+  /** `pubky://…/<lock_id>.json` → `<lock_id>`, or a typed error for a malformed lock URL. */
+  private static requireLockId(lockUrl: string, operation: string): string {
+    const lockId = LockContentParser.lockIdFromUrl(lockUrl);
+    if (!lockId) {
+      throw Err.validation(ValidationErrorCode.INVALID_INPUT, 'lock URL has no lock id', {
+        service: ErrorService.Locks,
+        operation,
+        context: { lockUrl },
+      });
+    }
+    return lockId;
   }
 
   /** Reads the guarded post + its attachments with the access credential. Throws when the post is unparseable. */
@@ -220,14 +353,7 @@ export class LocksApplication {
     readerPubky,
     content,
   }: TReplicateUnlockedContentParams): Promise<void> {
-    const lockId = LockContentParser.lockIdFromUrl(lockUrl);
-    if (!lockId) {
-      throw Err.validation(ValidationErrorCode.INVALID_INPUT, 'lock URL has no lock id to replicate under', {
-        service: ErrorService.Locks,
-        operation: 'replicateUnlockedContent',
-        context: { lockUrl },
-      });
-    }
+    const lockId = this.requireLockId(lockUrl, 'replicateUnlockedContent');
 
     for (const attachment of content.attachments) {
       await HomeserverService.putBlob({

--- a/src/core/application/locks/locks.types.ts
+++ b/src/core/application/locks/locks.types.ts
@@ -1,10 +1,47 @@
-import type { LockFile, ReplicatedPost, TGuardedResource, TUnlockedContent } from '@/services/locks/locks.types';
+import type {
+  LockFile,
+  ReplicatedPost,
+  TGuardedResource,
+  TUnlockedContent,
+  TVerificationStatus,
+} from '@/services/locks/locks.types';
 
 /** Params for the reader unlock flow. `lockUrl` is the post's public `lock.json` URL. */
 export type TUnlockContentParams = {
   lockFile: LockFile;
   lockUrl: string;
   password: string;
+};
+
+/** Params to read or write the bundle id the reader saved for one lock (`/priv/social/purchases/<lockId>.json`). */
+export type TPurchaseBundleIdParams = {
+  lockUrl: string;
+  readerPubky: string;
+};
+
+/** A payment lock as seen by one reader: the lock file, its public URL, and the reader. */
+export type TPaymentLockParams = TPurchaseBundleIdParams & {
+  lockFile: LockFile;
+};
+
+/**
+ * Params to start a payment. `rejectBundleId` is a saved id known to have ended `failed`/`expired`;
+ * it is never reused, a fresh one is minted instead.
+ */
+export type TStartPaymentParams = TPaymentLockParams & {
+  rejectBundleId: string | null;
+};
+
+/** The bundle id the proof was submitted with, and the verification status the server answered. */
+export type TStartPaymentResult = {
+  bundleId: string;
+  status: TVerificationStatus;
+};
+
+/** A submitted payment: the lock file and the bundle id the proof was submitted with. */
+export type TPaymentBundleParams = {
+  lockFile: LockFile;
+  bundleId: string;
 };
 
 /** Params for reading the guarded content after unlock, authorized by `credential`. */

--- a/src/core/controllers/locks/locks.test.ts
+++ b/src/core/controllers/locks/locks.test.ts
@@ -20,6 +20,13 @@ const mocks = vi.hoisted(() => ({
   setLockServiceConfig: vi.fn(),
   createLockContent: vi.fn(),
   fetchLockFile: vi.fn(),
+  hasPaykitReceiver: vi.fn(),
+  fetchPurchaseBundleId: vi.fn(),
+  fetchPaidContent: vi.fn(),
+  startPayment: vi.fn(),
+  fetchPaidContentIfCompleted: vi.fn(),
+  fetchPurchasedLockIds: vi.fn(),
+  fetchPaymentStatus: vi.fn(),
   unlockContent: vi.fn(),
   fetchUnlockedContent: vi.fn(),
   replicateUnlockedContent: vi.fn(),
@@ -38,6 +45,13 @@ vi.mock('@/application/locks/locks', () => ({
     setLockServiceConfig: mocks.setLockServiceConfig,
     createLockContent: mocks.createLockContent,
     fetchLockFile: mocks.fetchLockFile,
+    hasPaykitReceiver: mocks.hasPaykitReceiver,
+    fetchPurchaseBundleId: mocks.fetchPurchaseBundleId,
+    fetchPaidContent: mocks.fetchPaidContent,
+    startPayment: mocks.startPayment,
+    fetchPaidContentIfCompleted: mocks.fetchPaidContentIfCompleted,
+    fetchPurchasedLockIds: mocks.fetchPurchasedLockIds,
+    fetchPaymentStatus: mocks.fetchPaymentStatus,
     unlockContent: mocks.unlockContent,
     fetchUnlockedContent: mocks.fetchUnlockedContent,
     replicateUnlockedContent: mocks.replicateUnlockedContent,
@@ -366,5 +380,43 @@ describe('LocksController.fetchOwnContent', () => {
 
     await expect(LocksController.fetchOwnContent(params)).resolves.toEqual(content);
     expect(mocks.fetchOwnContent).toHaveBeenCalledWith(params);
+  });
+});
+
+describe('LocksController (payment delegation)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['hasPaykitReceiver', 'hasPaykitReceiver', 'reader1', true],
+    ['fetchPurchasedLockIds', 'fetchPurchasedLockIds', { readerPubky: 'reader1' }, ['lock1']],
+    ['fetchPurchaseBundleId', 'fetchPurchaseBundleId', { lockUrl: 'u', readerPubky: 'r' }, 'b'],
+    [
+      'startPayment',
+      'startPayment',
+      { lockFile: MOCK_LOCK_FILE, lockUrl: 'u', readerPubky: 'r', rejectBundleId: null },
+      { bundleId: 'b', status: 'pending' },
+    ],
+    [
+      'fetchPaidContentIfCompleted',
+      'fetchPaidContentIfCompleted',
+      { lockFile: MOCK_LOCK_FILE, lockUrl: 'u', readerPubky: 'r' },
+      null,
+    ],
+    ['fetchPaymentStatus', 'fetchPaymentStatus', { lockFile: MOCK_LOCK_FILE, bundleId: 'b' }, null],
+    [
+      'fetchPaidContent',
+      'fetchPaidContent',
+      { lockFile: MOCK_LOCK_FILE, bundleId: 'b' },
+      { post: {}, attachments: [] },
+    ],
+  ])('%s delegates to the application and returns its result', async (method, target, params, result) => {
+    const application = asOpaque<Record<string, ReturnType<typeof vi.fn>>>(LocksApplication);
+    application[target].mockResolvedValue(result);
+    const controller = asOpaque<Record<string, (arg?: unknown) => Promise<unknown>>>(LocksController);
+
+    await expect(controller[method](params)).resolves.toEqual(result);
+    expect(application[target]).toHaveBeenCalledWith(params);
   });
 });

--- a/src/core/controllers/locks/locks.ts
+++ b/src/core/controllers/locks/locks.ts
@@ -6,7 +6,12 @@ import type {
   TFetchReplicatedContentParams,
   TFetchUnlockedContentParams,
   TFetchUnlockedListParams,
+  TPaymentBundleParams,
+  TPaymentLockParams,
+  TPurchaseBundleIdParams,
   TReplicateUnlockedContentParams,
+  TStartPaymentParams,
+  TStartPaymentResult,
   TUnlockContentParams,
 } from '@/application/locks/locks.types';
 import { isAppError, isAuthError } from '@/libs/error/error.utils';
@@ -25,6 +30,7 @@ import type {
   TUnlockedContent,
   TUnlockedListItem,
   TUnlockResult,
+  TVerificationStatus,
 } from '@/services/locks/locks.types';
 import { useLocksAuthStore } from '@/stores/locksAuth/locksAuth.store';
 
@@ -33,7 +39,7 @@ const SIGNOUT_TIMEOUT_MS = 3000;
 
 /**
  * Entry point for the Lock Server: auth (mirrors `AuthController`), publishing locked content
- * (creator), and reading a lock's public `lock.json` (reader).
+ * (creator), reading a lock's public `lock.json` and unlocking it (reader).
  */
 export class LocksController {
   private constructor() {} // Prevent instantiation
@@ -174,9 +180,44 @@ export class LocksController {
     return LockContentParser.parse(content);
   }
 
-  /** Reader unlock: submit the proof for a resolved lock file, verify, and return the access credential. */
+  /** Password unlock (blocking submit+poll). TODO:[Locks] #2369 — deleted with the password UI. */
   static unlock(params: TUnlockContentParams): Promise<TUnlockResult> {
     return LocksApplication.unlockContent(params);
+  }
+
+  /** Whether the reader's wallet has published a Paykit receiver. */
+  static hasPaykitReceiver(readerPubky: string): Promise<boolean> {
+    return LocksApplication.hasPaykitReceiver(readerPubky);
+  }
+
+  /** The bundle id saved on the reader's own homeserver for this lock, or null; an unreadable file throws. */
+  static fetchPurchaseBundleId(params: TPurchaseBundleIdParams): Promise<string | null> {
+    return LocksApplication.fetchPurchaseBundleId(params);
+  }
+
+  /** Saves a bundle id on the reader's homeserver and submits the payment proof to the Lock Server. */
+  static startPayment(params: TStartPaymentParams): Promise<TStartPaymentResult> {
+    return LocksApplication.startPayment(params);
+  }
+
+  /** One read of the payment's verification status, or null when the submission never reached the server. */
+  static fetchPaymentStatus(params: TPaymentBundleParams): Promise<TVerificationStatus | null> {
+    return LocksApplication.fetchPaymentStatus(params);
+  }
+
+  /** Lock ids the reader has started a payment for (pending and failed included) — one listing serves every lock post on screen. */
+  static fetchPurchasedLockIds(params: TFetchUnlockedListParams): Promise<string[]> {
+    return LocksApplication.fetchPurchasedLockIds(params);
+  }
+
+  /** Gets an access credential for a paid bundle id from the Lock Server, then downloads the post + attachments with it. */
+  static fetchPaidContent(params: TPaymentBundleParams): Promise<TUnlockedContent> {
+    return LocksApplication.fetchPaidContent(params);
+  }
+
+  /** `fetchPaidContent` for the background recovery, which knows neither the bundle id nor the status; null unless `completed`. */
+  static fetchPaidContentIfCompleted(params: TPaymentLockParams): Promise<TUnlockedContent | null> {
+    return LocksApplication.fetchPaidContentIfCompleted(params);
   }
 
   /** Reads the guarded post + attachments after unlock, using the access credential. */

--- a/src/core/pipes/locks/locks.parser.test.ts
+++ b/src/core/pipes/locks/locks.parser.test.ts
@@ -145,9 +145,71 @@ describe('LockProofBundler', () => {
     };
     expect(LockProofBundler.build(twoCriteria, LOCK_URL, 'b').proofs).toHaveLength(2);
   });
+
+  describe('buildPayment', () => {
+    it('builds one empty-payload proof with the reader pubky at the top level', () => {
+      const paymentLock = {
+        ...MOCK_LOCK_FILE,
+        criteria: [{ criterion_id: 'criterion-1', verifier_type: 'paykit-payment', params: { amount: '1000' } }],
+      };
+      expect(LockProofBundler.buildPayment(paymentLock, LOCK_URL, 'bundle-1', 'reader123')).toEqual({
+        version: 1,
+        bundle_id: 'bundle-1',
+        pubky_lock_resource: `${MOCK_LOCK_AUTHOR_PUBKY}/pub/locks.app/lock1.json`,
+        reader_public_key: 'pubkyreader123',
+        proofs: [{ criterion_id: 'criterion-1', verifier_type: 'paykit-payment', payload: {} }],
+      });
+    });
+
+    it('throws when the lock file has no criterion', () => {
+      const empty = { ...MOCK_LOCK_FILE, criteria: [] };
+      expect(() => LockProofBundler.buildPayment(empty, LOCK_URL, 'b', 'r')).toThrow();
+    });
+  });
 });
 
 describe('GuardedContentParser', () => {
+  describe('purchase bundle id file', () => {
+    it('builds the purchase URL beside the replica, not inside it', () => {
+      expect(GuardedContentParser.purchaseUrl('reader123', 'lock1')).toBe(
+        'pubky://reader123/priv/social/purchases/lock1.json',
+      );
+    });
+
+    it('lists the purchased lock ids from the purchases root', () => {
+      expect(
+        GuardedContentParser.purchasedLockIds([
+          'pubky://reader1/priv/social/purchases/lock1.json',
+          'pubky://reader1/priv/social/purchases/lock2.json',
+        ]),
+      ).toEqual(['lock1', 'lock2']);
+    });
+
+    it.each([
+      ['a file outside the purchases root', 'pubky://reader1/priv/social/unlocked/lock1/post.json'],
+      ['a nested path', 'pubky://reader1/priv/social/purchases/lock1/extra.json'],
+      ['a non-json entry', 'pubky://reader1/priv/social/purchases/lock1'],
+      ['an empty id', 'pubky://reader1/priv/social/purchases/.json'],
+    ])('ignores %s', (_label, url) => {
+      expect(GuardedContentParser.purchasedLockIds([url])).toEqual([]);
+    });
+
+    it('round-trips a bundle id through build + parse', () => {
+      const bytes = new TextEncoder().encode(GuardedContentParser.buildPurchaseFile('bundle-1'));
+      expect(GuardedContentParser.parsePurchaseFile(bytes)).toBe('bundle-1');
+    });
+
+    it.each([
+      ['not JSON', 'garbage'],
+      ['not an object', '"bundle-1"'],
+      ['missing the field', '{}'],
+      ['an empty id', '{"bundle_id":""}'],
+      ['a non-string id', '{"bundle_id":7}'],
+    ])('parses %s to null', (_label, raw) => {
+      expect(GuardedContentParser.parsePurchaseFile(new TextEncoder().encode(raw))).toBeNull();
+    });
+  });
+
   describe('toReadPath', () => {
     it('strips the guarded content prefix to the relative read path', () => {
       expect(GuardedContentParser.toReadPath('/priv/locks.app/content/nested/a.txt')).toBe('nested/a.txt');

--- a/src/core/pipes/locks/locks.parser.ts
+++ b/src/core/pipes/locks/locks.parser.ts
@@ -1,10 +1,15 @@
-import { isPositiveIntegerString, isPubkyIdentifier } from '@/libs/utils/utils';
+import type { ZodType } from 'zod';
+import { ValidationErrorCode } from '@/libs/error/error.codes';
+import { Err } from '@/libs/error/error.factories';
+import { ErrorService } from '@/libs/error/error.types';
+import { isPositiveIntegerString, isPubkyIdentifier, withPubkyPrefix } from '@/libs/utils/utils';
 import {
   type GuardedPost,
   guardedPostSchema,
   type LockFile,
   type LockPostContent,
   lockPostContentSchema,
+  purchaseFileSchema,
   type ReplicatedPost,
   replicatedPostSchema,
   type TProof,
@@ -15,6 +20,8 @@ import {
 const GUARDED_CONTENT_PREFIX = '/priv/locks.app/content/';
 /** Where a reader keeps its own copy of content it has unlocked. */
 const UNLOCKED_PREFIX = '/priv/social/unlocked/';
+/** Where a reader keeps each purchase's bundle id; without it the paid content cannot be fetched again. */
+const PURCHASES_PREFIX = '/priv/social/purchases/';
 /** Uploaded last, so its presence proves every attachment before it succeeded. */
 const UNLOCKED_POST_FILE = 'post.json';
 
@@ -99,8 +106,37 @@ export class LockFileParser {
 export class LockProofBundler {
   private constructor() {}
 
+  /**
+   * Payment bundle: exactly one proof with an empty payload, plus the reader's pubky at the top
+   * level — Paykit resolves the payment-request delivery address from it. Resubmitting the exact
+   * same bundle is a safe replay; any variation returns `409 task_state_conflict`, so it must be
+   * built deterministically from the same inputs every time.
+   */
+  static buildPayment(
+    lockFile: LockFile,
+    lockUrl: string,
+    bundleId: string,
+    readerPubky: string,
+  ): TSubmittedProofBundle {
+    const criterionId = lockFile.criteria[0]?.criterion_id;
+    if (!criterionId) {
+      throw Err.validation(ValidationErrorCode.INVALID_INPUT, 'payment lock file has no criterion', {
+        service: ErrorService.Locks,
+        operation: 'LockProofBundler.buildPayment',
+        context: { lockUrl },
+      });
+    }
+    return {
+      version: 1,
+      bundle_id: bundleId,
+      pubky_lock_resource: lockUrl.replace(/^pubky:\/\//, ''),
+      reader_public_key: withPubkyPrefix(readerPubky),
+      proofs: [{ criterion_id: criterionId, verifier_type: VerifierType.PAYMENT, payload: {} }],
+    };
+  }
+
+  // TODO:[Locks] #2369 — password and `dev-static` go away here.
   static build(lockFile: LockFile, lockUrl: string, bundleId: string): TSubmittedProofBundle {
-    // TODO:[Locks] #2369 — password and `dev-static` all go away here.
     const proofs: TProof[] = lockFile.criteria.map((criterion) => ({
       criterion_id: criterion.criterion_id,
       verifier_type: criterion.verifier_type,
@@ -141,6 +177,57 @@ export class GuardedContentParser {
   /** Reader's unlocked root: `pubky://<reader>/priv/social/unlocked/`. */
   static unlockedRootUrl(readerPubky: string): string {
     return `pubky://${readerPubky}${UNLOCKED_PREFIX}`;
+  }
+
+  /**
+   * Reader's bundle id file for one lock: `pubky://<reader>/priv/social/purchases/<lockId>.json`.
+   * Beside the replica, not inside it, so deleting the replica keeps the bundle id.
+   */
+  static purchaseUrl(readerPubky: string, lockId: string): string {
+    return `pubky://${readerPubky}${PURCHASES_PREFIX}${lockId}.json`;
+  }
+
+  /** Reader's purchases root: `pubky://<reader>/priv/social/purchases/`. */
+  static purchasesRootUrl(readerPubky: string): string {
+    return `pubky://${readerPubky}${PURCHASES_PREFIX}`;
+  }
+
+  /**
+   * Picks the `<lockId>` out of each purchases-root file URL:
+   * `pubky://<reader>/priv/social/purchases/<lockId>.json` → `<lockId>`.
+   * Anything else in the directory is ignored rather than guessed at.
+   */
+  static purchasedLockIds(fileUrls: string[]): string[] {
+    const ids: string[] = [];
+    for (const url of fileUrls) {
+      const start = url.indexOf(PURCHASES_PREFIX);
+      if (start === -1) continue;
+      if (url.slice(start + PURCHASES_PREFIX.length).includes('/')) continue;
+      const lockId = LockContentParser.lockIdFromUrl(url);
+      if (lockId) ids.push(lockId);
+    }
+    return ids;
+  }
+
+  /** Body of the purchase file (`{"bundle_id":…}`); `parsePurchaseFile` reads it back. */
+  static buildPurchaseFile(bundleId: string): string {
+    return JSON.stringify({ bundle_id: bundleId });
+  }
+
+  /** Bundle id inside the purchase file, or null when the bytes are unreadable. */
+  static parsePurchaseFile(bytes: Uint8Array): string | null {
+    return this.parseJsonBytes(bytes, purchaseFileSchema)?.bundle_id ?? null;
+  }
+
+  private static parseJsonBytes<T>(bytes: Uint8Array, schema: ZodType<T>): T | null {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(new TextDecoder().decode(bytes));
+    } catch {
+      return null;
+    }
+    const result = schema.safeParse(raw);
+    return result.success ? result.data : null;
   }
 
   /**
@@ -191,25 +278,11 @@ export class GuardedContentParser {
 
   /** Parses the reader's replicated `post.json` bytes. Returns null on bad JSON. */
   static parseReplicatedPost(bytes: Uint8Array): ReplicatedPost | null {
-    let raw: unknown;
-    try {
-      raw = JSON.parse(new TextDecoder().decode(bytes));
-    } catch {
-      return null;
-    }
-    const result = replicatedPostSchema.safeParse(raw);
-    return result.success ? result.data : null;
+    return this.parseJsonBytes(bytes, replicatedPostSchema);
   }
 
   /** Parses the guarded primary bytes (a `PubkyAppPost` JSON) into the reader post shape. */
   static parsePost(bytes: Uint8Array): GuardedPost | null {
-    let raw: unknown;
-    try {
-      raw = JSON.parse(new TextDecoder().decode(bytes));
-    } catch {
-      return null;
-    }
-    const result = guardedPostSchema.safeParse(raw);
-    return result.success ? result.data : null;
+    return this.parseJsonBytes(bytes, guardedPostSchema);
   }
 }

--- a/src/core/services/locks/locks.test.ts
+++ b/src/core/services/locks/locks.test.ts
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => {
     addPkarrRelay: vi.fn(),
     setLocalTestnetHomeserver: vi.fn(),
     forServerWithOptions: vi.fn(() => fakeLocks),
+    hasPaykitDataWithOptions: vi.fn(async () => true),
     getTestnet: vi.fn(() => true),
     getLockServer: vi.fn((): string | undefined => 'lockserverpubky'),
     getPaykitServerUrl: vi.fn((): string | undefined => 'https://paykit.server'),
@@ -130,6 +131,7 @@ vi.mock('@pubky/locks-sdk', () => {
     Locks: {
       forServerWithOptions: mocks.forServerWithOptions,
       readContentLockWithOptions: mocks.readContentLockWithOptions,
+      hasPaykitDataWithOptions: mocks.hasPaykitDataWithOptions,
     },
   };
 });
@@ -419,6 +421,49 @@ describe('LocksService (reader unlock)', () => {
       expect.objectContaining({ creator: 'creator-b', bundle_id: 'b1' }),
     );
     expect(task).toEqual({ status: 'completed' });
+  });
+
+  it('submitProof sends the bundle to the viewer without a password', async () => {
+    const bundle = { version: 1, bundle_id: 'b1', pubky_lock_resource: 'creator/pub/l.json', proofs: [] };
+    const task = await LocksService.submitProof(bundle);
+
+    expect(mocks.fakeViewer.submitProofBundle).toHaveBeenCalledWith(bundle);
+    expect(task).toEqual({ status: 'pending' });
+  });
+
+  it('lookupVerificationTask resolves to null when the server has no task for the bundle id', async () => {
+    mocks.fakeViewer.lookupVerificationTask.mockRejectedValueOnce(
+      new Error('Lock Server request failed with HTTP 404'),
+    );
+    await expect(LocksService.lookupVerificationTask('creator-b', 'b1')).resolves.toBeNull();
+  });
+
+  it('lookupVerificationTask rethrows non-404 failures', async () => {
+    mocks.fakeViewer.lookupVerificationTask.mockRejectedValueOnce(
+      new Error('Lock Server request failed with HTTP 500'),
+    );
+
+    const error = await LocksService.lookupVerificationTask('creator-b', 'b1').catch((e: unknown) => e);
+    expect(isAppError(error)).toBe(true);
+    expect(error).toMatchObject({ operation: 'LocksService.lookupVerificationTask' });
+  });
+
+  // The 404 is read from the message text, so a string rejection must count the same as an Error.
+  it('lookupVerificationTask reads the 404 from a non-Error rejection too', async () => {
+    mocks.fakeViewer.lookupVerificationTask.mockRejectedValueOnce('HTTP 404');
+    await expect(LocksService.lookupVerificationTask('creator-b', 'b1')).resolves.toBeNull();
+  });
+
+  it('lookupVerificationTask does not treat other 4xx as missing', async () => {
+    mocks.fakeViewer.lookupVerificationTask.mockRejectedValueOnce(
+      new Error('Lock Server request failed with HTTP 403'),
+    );
+    await expect(LocksService.lookupVerificationTask('creator-b', 'b1')).rejects.toThrow();
+  });
+
+  it('hasPaykitReceiver asks the SDK with the pubky-prefixed reader', async () => {
+    await expect(LocksService.hasPaykitReceiver('reader123')).resolves.toBe(true);
+    expect(mocks.hasPaykitDataWithOptions).toHaveBeenCalledWith('pubkyreader123', expect.anything());
   });
 
   it('issueAccessCredential returns the bearer credential and expiry', async () => {

--- a/src/core/services/locks/locks.ts
+++ b/src/core/services/locks/locks.ts
@@ -14,6 +14,7 @@ import { AuthErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';
 import { toAppError } from '@/libs/error/error.utils';
+import { withPubkyPrefix } from '@/libs/utils/utils';
 import { useLocksAuthStore } from '@/stores/locksAuth/locksAuth.store';
 import type {
   TAccessCredential,
@@ -134,23 +135,47 @@ export class LocksService {
   }
 
   // Reader calls are public (no session) → `toAppError`, not `toLocksError` (a 401 isn't an expired session).
-  // TODO:[Locks] #2369 — password and `dev-static` all go away here.
-  static async submitProofBundle(bundle: TSubmittedProofBundle, _password: string): Promise<TVerificationTask> {
+  static async submitProof(bundle: TSubmittedProofBundle): Promise<TVerificationTask> {
     try {
       const viewer = await this.getViewer();
       return (await viewer.submitProofBundle(bundle)) as TVerificationTask;
     } catch (error) {
-      throw toAppError(error, ErrorService.Locks, 'LocksService.submitProofBundle');
+      throw toAppError(error, ErrorService.Locks, 'LocksService.submitProof');
     }
   }
 
-  static async lookupVerificationTask(creator: string, bundleId: string): Promise<TVerificationTask> {
+  // TODO:[Locks] #2369 — password and `dev-static` all go away here; delete this wrapper with them.
+  static async submitProofBundle(bundle: TSubmittedProofBundle, _password: string): Promise<TVerificationTask> {
+    return this.submitProof(bundle);
+  }
+
+  /**
+   * Whether the reader has published anything under their public Paykit namespace — the gate
+   * between the pay screen and the install-Bitkit screen. Presence only: it does not prove the
+   * receiver is valid or ready, so a submission can still fail after this returns true.
+   */
+  static async hasPaykitReceiver(readerPubky: string): Promise<boolean> {
+    try {
+      await ensureLocksSdkReady();
+      return await Locks.hasPaykitDataWithOptions(withPubkyPrefix(readerPubky), buildLocksOptions());
+    } catch (error) {
+      throw toAppError(error, ErrorService.Locks, 'LocksService.hasPaykitReceiver');
+    }
+  }
+
+  /**
+   * Null when the Lock Server has no task for this bundle id (the submission never landed). The SDK
+   * exposes no status field, so the 404 is read from the message, like `toLocksError` does for 401.
+   */
+  static async lookupVerificationTask(creator: string, bundleId: string): Promise<TVerificationTask | null> {
     try {
       const viewer = await this.getViewer();
       return (await viewer.lookupVerificationTask(
         new VerificationTaskHandleOptions(creator, bundleId),
       )) as TVerificationTask;
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes('HTTP 404')) return null;
       throw toAppError(error, ErrorService.Locks, 'LocksService.lookupVerificationTask');
     }
   }

--- a/src/core/services/locks/locks.types.ts
+++ b/src/core/services/locks/locks.types.ts
@@ -233,6 +233,9 @@ export const replicatedPostSchema = z.object({
 
 export type ReplicatedPost = z.infer<typeof replicatedPostSchema>;
 
+/** Reader's `/priv/social/purchases/<lockId>.json`: the bundle id a payment was started with. */
+export const purchaseFileSchema = z.object({ bundle_id: z.string().min(1) });
+
 export interface TUnlockedListItem {
   lockId: string;
   post: ReplicatedPost;
@@ -279,6 +282,8 @@ export interface TSubmittedProofBundle {
   bundle_id: string;
   /** Public lock file as `<creator>/pub/locks.app/<lock_id>.json` — no `pubky://` scheme. */
   pubky_lock_resource: string;
+  /** Payment bundles only (`pubky` prefix included): where Paykit delivers the payment request. */
+  reader_public_key?: string;
   proofs: TProof[];
 }
 

--- a/src/hooks/usePayToUnlock/usePayToUnlock.test.ts
+++ b/src/hooks/usePayToUnlock/usePayToUnlock.test.ts
@@ -1,0 +1,483 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LocksController } from '@/controllers/locks/locks';
+import type { LockFile, TUnlockedContent, TVerificationStatus } from '@/services/locks/locks.types';
+import { asOpaque } from '@/test-utils/type-assertions';
+import { POLL_INTERVAL_MS, STALL_AFTER_MS, usePayToUnlock } from './usePayToUnlock';
+
+vi.mock('@/controllers/locks/locks', () => ({
+  LocksController: {
+    fetchPurchaseBundleId: vi.fn(),
+    startPayment: vi.fn(),
+    fetchPaymentStatus: vi.fn(),
+    fetchPaidContent: vi.fn(),
+    hasPaykitReceiver: vi.fn(),
+  },
+}));
+
+const authState = vi.hoisted(() => ({ currentUserPubky: 'reader1' as string | null, session: {} as object | null }));
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: (selector: (s: typeof authState) => unknown) => selector(authState),
+}));
+
+const toastMock = vi.hoisted(() => vi.fn());
+vi.mock('@/molecules/Toaster/toast', () => ({ toast: (...args: unknown[]) => toastMock(...args) }));
+
+const lockFile = asOpaque<LockFile>({
+  creator: 'pubkybob',
+  criteria: [{ criterion_id: 'criterion-1', verifier_type: 'paykit-payment', params: { amount: '1000' } }],
+});
+const LOCK_URL = 'pubky://pubkybob/pub/locks.app/LOCK1.json';
+
+const unlockedContent = asOpaque<TUnlockedContent>({
+  post: { content: 'paid', kind: 'short', attachments: null },
+  attachments: [],
+});
+
+const onPurchased = vi.fn();
+const renderPay = (onCompleted = vi.fn()) => ({
+  onCompleted,
+  ...renderHook(() => usePayToUnlock({ open: true, lockUrl: LOCK_URL, lockFile, onCompleted, onPurchased })),
+});
+const renderPayWith = (initialProps: { open: boolean }, onCompleted = vi.fn()) => ({
+  onCompleted,
+  ...renderHook(
+    (props: { open: boolean }) => usePayToUnlock({ ...props, lockUrl: LOCK_URL, lockFile, onCompleted, onPurchased }),
+    { initialProps },
+  ),
+});
+
+const statusCalls = () => vi.mocked(LocksController.fetchPaymentStatus).mock.calls.length;
+
+describe('usePayToUnlock (opening)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.currentUserPubky = 'reader1';
+    authState.session = {};
+    vi.mocked(LocksController.fetchPaidContent).mockResolvedValue(unlockedContent);
+  });
+
+  it('shows Pay when nothing is stored and the wallet has a receiver', async () => {
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue(null);
+    vi.mocked(LocksController.hasPaykitReceiver).mockResolvedValue(true);
+
+    const { result } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('pay'));
+    expect(LocksController.startPayment).not.toHaveBeenCalled();
+  });
+
+  it('shows the install steps when nothing is stored and there is no receiver', async () => {
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue(null);
+    vi.mocked(LocksController.hasPaykitReceiver).mockResolvedValue(false);
+
+    const { result } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('install'));
+    expect(LocksController.startPayment).not.toHaveBeenCalled();
+  });
+
+  // Saved id with no status: the submission never reached the server. Pay again with the SAME id —
+  // never an indefinite waiting state.
+  it('offers Pay again when the saved bundle id has no status behind it', async () => {
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue('stored-1');
+    vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValue(null);
+
+    const { result } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('pay'));
+    expect(LocksController.startPayment).not.toHaveBeenCalled();
+    expect(LocksController.hasPaykitReceiver).not.toHaveBeenCalled(); // a purchase exists; the gate is moot
+  });
+
+  it('resumes waiting when the saved bundle id is still pending', async () => {
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue('stored-1');
+    vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValue('pending');
+
+    const { result } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('waiting'));
+    expect(LocksController.startPayment).not.toHaveBeenCalled();
+  });
+
+  it('shows the paid confirmation when the saved bundle id already completed', async () => {
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue('stored-1');
+    vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValue('completed');
+
+    const { result, onCompleted } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('paid'));
+    expect(LocksController.fetchPaidContent).toHaveBeenCalledWith({ lockFile, bundleId: 'stored-1' });
+    expect(onCompleted).not.toHaveBeenCalled();
+
+    act(() => result.current.viewContent());
+    act(() => result.current.viewContent());
+    expect(onCompleted).toHaveBeenCalledWith(unlockedContent);
+    expect(onCompleted).toHaveBeenCalledTimes(1);
+    expect(LocksController.startPayment).not.toHaveBeenCalled();
+  });
+
+  // The session rehydrates after `currentUserPubky`; reading storage without it silently reports
+  // "no purchase", which would fail OPEN — so the hook stays on checking until it lands.
+  it('stays on checking while the session is still restoring', async () => {
+    authState.session = null;
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue(null);
+    vi.mocked(LocksController.hasPaykitReceiver).mockResolvedValue(true);
+
+    const { result } = renderPay();
+    await act(async () => {});
+    expect(result.current.stage).toBe('checking');
+    expect(LocksController.startPayment).not.toHaveBeenCalled();
+    expect(LocksController.fetchPurchaseBundleId).not.toHaveBeenCalled();
+  });
+
+  // Fail closed: the file may exist but be unreadable — minting a fresh id could pay twice.
+  it('blocks paying when the saved bundle id cannot be read', async () => {
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockRejectedValue(new Error('unreadable'));
+
+    const { result } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('blocked'));
+    expect(LocksController.startPayment).not.toHaveBeenCalled();
+  });
+
+  // The stored id can change while the modal is closed (another tab paid), so a reopen must not
+  // trust the stage it closed on.
+  it('re-checks on reopen', async () => {
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue(null);
+    vi.mocked(LocksController.hasPaykitReceiver).mockResolvedValue(true);
+
+    const { result, rerender } = renderPayWith({ open: true });
+    await waitFor(() => expect(result.current.stage).toBe('pay'));
+
+    rerender({ open: false });
+    rerender({ open: true });
+    expect(result.current.stage).toBe('checking');
+    expect(LocksController.fetchPurchaseBundleId).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('usePayToUnlock (submit)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.currentUserPubky = 'reader1';
+    authState.session = {};
+    vi.mocked(LocksController.hasPaykitReceiver).mockResolvedValue(true);
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue(null);
+    vi.mocked(LocksController.startPayment).mockResolvedValue({ bundleId: 'fresh-1', status: 'pending' });
+  });
+
+  it('starts the payment and moves to waiting', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValue('pending');
+
+      const { result } = renderPay();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.stage).toBe('pay');
+
+      await act(async () => {
+        result.current.submit();
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.stage).toBe('waiting');
+      expect(LocksController.startPayment).toHaveBeenCalledWith({
+        lockFile,
+        lockUrl: LOCK_URL,
+        readerPubky: 'reader1',
+        rejectBundleId: null,
+      });
+      // The submit response already carried a status, so the first lookup waits one interval.
+      expect(LocksController.fetchPaymentStatus).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      });
+      expect(LocksController.fetchPaymentStatus).toHaveBeenCalledTimes(1);
+      expect(LocksController.fetchPaymentStatus).toHaveBeenCalledWith({ lockFile, bundleId: 'fresh-1' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A saved id with no status never reached the server, so nothing is rejected and the same id is sent.
+  it('re-submits with the saved id when it had no status behind it', async () => {
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue('stored-1');
+    vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValue(null);
+
+    const { result } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('pay'));
+    result.current.submit();
+
+    await waitFor(() => expect(LocksController.startPayment).toHaveBeenCalled());
+    expect(LocksController.startPayment).toHaveBeenCalledWith(expect.objectContaining({ rejectBundleId: null }));
+    expect(LocksController.hasPaykitReceiver).not.toHaveBeenCalled();
+  });
+
+  // failed/expired cannot be retried — the dead id is handed over so the application replaces it,
+  // and only when the reader presses again: a dead payment must not re-charge anyone on its own.
+  it.each(['failed', 'expired'] as const)('rejects the bundle id whose payment ended in %s', async (status) => {
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue('dead-1');
+    vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValue(status);
+
+    const { result } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('pay'));
+    expect(LocksController.startPayment).not.toHaveBeenCalled();
+    result.current.submit();
+
+    await waitFor(() => expect(LocksController.startPayment).toHaveBeenCalled());
+    expect(LocksController.startPayment).toHaveBeenCalledWith(expect.objectContaining({ rejectBundleId: 'dead-1' }));
+  });
+
+  it('stays on Pay with a toast when the submission fails (wallet not ready or Paykit down)', async () => {
+    vi.mocked(LocksController.startPayment).mockRejectedValue(new Error('HTTP 502'));
+
+    const { result } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('pay'));
+    result.current.submit();
+
+    await waitFor(() => expect(toastMock).toHaveBeenCalled());
+    expect(result.current.stage).toBe('pay');
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  // Two clicks in the same tick are the classic shape of a double payment.
+  it('ignores a second press while a submission is in flight', async () => {
+    const { result } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('pay'));
+    result.current.submit();
+    result.current.submit();
+
+    await waitFor(() => expect(LocksController.startPayment).toHaveBeenCalled());
+    expect(LocksController.startPayment).toHaveBeenCalledTimes(1);
+  });
+
+  // The session listing was taken before this purchase existed, so the recovery path needs telling.
+  it('announces the purchase so this session can recover it', async () => {
+    const { result } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('pay'));
+    result.current.submit();
+
+    await waitFor(() => expect(onPurchased).toHaveBeenCalledWith('LOCK1'));
+  });
+});
+
+describe('usePayToUnlock (finishing)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.currentUserPubky = 'reader1';
+    authState.session = {};
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue('stored-1');
+    vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValue('completed');
+  });
+
+  // A failed read must leave the reader something to press, not a spinner.
+  it('parks in the waiting stage when the completion fails, so Check again is reachable', async () => {
+    vi.mocked(LocksController.fetchPaidContent).mockRejectedValue(new Error('down'));
+
+    const { result, onCompleted } = renderPay();
+
+    await waitFor(() => expect(result.current.isStalled).toBe(true));
+    expect(result.current.stage).toBe('waiting');
+    expect(onCompleted).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ description: expect.stringContaining('went through') }),
+    );
+  });
+
+  // Parked with no polling behind it (the purchase was already complete when the modal opened):
+  // recheck still has to retry, which it cannot do without a remembered bundle.
+  it('retries the completion when Check again is pressed', async () => {
+    vi.mocked(LocksController.fetchPaidContent).mockRejectedValue(new Error('down'));
+    const { result, onCompleted } = renderPay();
+    await waitFor(() => expect(result.current.isStalled).toBe(true));
+
+    vi.mocked(LocksController.fetchPaidContent).mockResolvedValue(unlockedContent);
+    const before = vi.mocked(LocksController.fetchPaidContent).mock.calls.length;
+    result.current.recheck();
+
+    await waitFor(() => expect(result.current.stage).toBe('paid'));
+    expect(onCompleted).not.toHaveBeenCalled();
+    act(() => result.current.viewContent());
+    expect(onCompleted).toHaveBeenCalledWith(unlockedContent);
+    expect(vi.mocked(LocksController.fetchPaidContent).mock.calls.length).toBeGreaterThan(before);
+  });
+});
+
+describe('usePayToUnlock (waiting)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.currentUserPubky = 'reader1';
+    authState.session = {};
+    vi.useFakeTimers();
+    vi.mocked(LocksController.fetchPurchaseBundleId).mockResolvedValue('stored-1');
+    vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValue('pending');
+    vi.mocked(LocksController.fetchPaidContent).mockResolvedValue(unlockedContent);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  const advance = (ms: number) =>
+    act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+    });
+
+  it('stops polling and shows the paid confirmation when a poll sees the payment complete', async () => {
+    vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValueOnce('pending').mockResolvedValueOnce('completed');
+
+    const { result, onCompleted } = renderPay();
+    await advance(0);
+    expect(result.current.stage).toBe('waiting');
+
+    await advance(POLL_INTERVAL_MS);
+    expect(LocksController.fetchPaidContent).toHaveBeenCalledWith({ lockFile, bundleId: 'stored-1' });
+    expect(result.current.stage).toBe('paid');
+    expect(onCompleted).not.toHaveBeenCalled();
+
+    const lookupsWhenDone = statusCalls();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      document.dispatchEvent(new Event('visibilitychange'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(statusCalls()).toBe(lookupsWhenDone);
+
+    act(() => result.current.viewContent());
+    expect(onCompleted).toHaveBeenCalledWith(unlockedContent);
+  });
+
+  it.each(['failed', 'expired'] as const)(
+    'offers Pay again with the dead id rejected when the poll reports %s',
+    async (status) => {
+      vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValueOnce('pending').mockResolvedValueOnce(status);
+      vi.mocked(LocksController.startPayment).mockResolvedValue({ bundleId: 'fresh-1', status: 'pending' });
+
+      const { result } = renderPay();
+      await advance(0);
+      expect(result.current.stage).toBe('waiting');
+
+      await advance(POLL_INTERVAL_MS);
+      expect(result.current.stage).toBe('pay');
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ description: expect.stringContaining(status) }));
+
+      const lookupsWhenDead = statusCalls();
+      await advance(POLL_INTERVAL_MS);
+      expect(statusCalls()).toBe(lookupsWhenDead);
+
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(statusCalls()).toBe(lookupsWhenDead);
+      expect(toastMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        result.current.submit();
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(LocksController.startPayment).toHaveBeenCalledWith(
+        expect.objectContaining({ rejectBundleId: 'stored-1' }),
+      );
+    },
+  );
+
+  it('keeps polling through a lookup error', async () => {
+    vi.mocked(LocksController.fetchPaymentStatus)
+      .mockResolvedValueOnce('pending')
+      .mockRejectedValueOnce(new Error('blip'));
+
+    const { result } = renderPay();
+    await advance(0);
+    expect(result.current.stage).toBe('waiting');
+    const lookupsAfterOpen = statusCalls();
+
+    await advance(POLL_INTERVAL_MS);
+    await advance(POLL_INTERVAL_MS);
+    expect(result.current.stage).toBe('waiting');
+    expect(result.current.isStalled).toBe(false);
+    expect(toastMock).not.toHaveBeenCalled();
+    expect(statusCalls()).toBe(lookupsAfterOpen + 2);
+  });
+
+  // A null mid-wait would mean the server lost the payment; one is treated like still-pending.
+  it('keeps polling when the server briefly reports no task', async () => {
+    vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValueOnce('pending').mockResolvedValueOnce(null);
+
+    const { result } = renderPay();
+    await advance(0);
+    expect(result.current.stage).toBe('waiting');
+    const lookupsAfterOpen = statusCalls();
+
+    await advance(POLL_INTERVAL_MS);
+    await advance(POLL_INTERVAL_MS);
+    expect(result.current.stage).toBe('waiting');
+    expect(result.current.isStalled).toBe(false);
+    expect(toastMock).not.toHaveBeenCalled();
+    expect(statusCalls()).toBe(lookupsAfterOpen + 2);
+  });
+
+  it('parks at the stall deadline and resumes with a fresh window on tab focus', async () => {
+    const { result } = renderPay();
+    await advance(0);
+    expect(result.current.stage).toBe('waiting');
+    // Only the open-time read so far; the first poll waits a full interval.
+    expect(LocksController.fetchPaymentStatus).toHaveBeenCalledTimes(1);
+    await advance(POLL_INTERVAL_MS - 1);
+    expect(LocksController.fetchPaymentStatus).toHaveBeenCalledTimes(1);
+    await advance(1);
+    expect(LocksController.fetchPaymentStatus).toHaveBeenCalledTimes(2);
+
+    // Run past the deadline: the loop parks.
+    await advance(STALL_AFTER_MS + POLL_INTERVAL_MS);
+    const lookupsWhenParked = statusCalls();
+    // Parked has to be visible: it is the only way back for a reader who never leaves the tab.
+    expect(result.current.isStalled).toBe(true);
+    expect(result.current.stage).toBe('waiting');
+
+    // Parked means parked: more time, no more lookups.
+    await advance(STALL_AFTER_MS);
+    expect(statusCalls()).toBe(lookupsWhenParked);
+
+    // The reader comes back from Bitkit: immediate lookup, and the loop truly resumes.
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 2);
+    });
+    expect(result.current.isStalled).toBe(false);
+    expect(statusCalls()).toBeGreaterThan(lookupsWhenParked + 1);
+  });
+
+  it('goes quiet when the modal closes mid-wait', async () => {
+    const { result, rerender } = renderPayWith({ open: true });
+    await advance(0);
+    expect(result.current.stage).toBe('waiting');
+
+    rerender({ open: false });
+    const lookupsWhenClosed = statusCalls();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 3);
+      document.dispatchEvent(new Event('visibilitychange'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(statusCalls()).toBe(lookupsWhenClosed);
+  });
+
+  // A lookup that was already in flight when the modal closed must not open content nobody asked for.
+  it('ignores a lookup that resolves after the modal closed', async () => {
+    let resolve: (status: TVerificationStatus) => void = () => {};
+    vi.mocked(LocksController.fetchPaymentStatus)
+      .mockResolvedValueOnce('pending')
+      .mockImplementationOnce(
+        () =>
+          new Promise((r) => {
+            resolve = r;
+          }),
+      );
+
+    const { result, rerender, onCompleted } = renderPayWith({ open: true });
+    await advance(0);
+    expect(result.current.stage).toBe('waiting');
+
+    await advance(POLL_INTERVAL_MS);
+    rerender({ open: false });
+    resolve('completed');
+    await advance(0);
+    expect(LocksController.fetchPaidContent).not.toHaveBeenCalled();
+    expect(onCompleted).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePayToUnlock/usePayToUnlock.test.ts
+++ b/src/hooks/usePayToUnlock/usePayToUnlock.test.ts
@@ -268,26 +268,27 @@ describe('usePayToUnlock (finishing)', () => {
     vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValue('completed');
   });
 
-  // A failed read must leave the reader something to press, not a spinner.
-  it('parks in the waiting stage when the completion fails, so Check again is reachable', async () => {
+  // The payment landed and only the read failed, so this must not share the waiting screen, which
+  // asks the reader to go pay.
+  it('lands on its own stage when the completion fails, so Check again is reachable', async () => {
     vi.mocked(LocksController.fetchPaidContent).mockRejectedValue(new Error('down'));
 
     const { result, onCompleted } = renderPay();
 
-    await waitFor(() => expect(result.current.isStalled).toBe(true));
-    expect(result.current.stage).toBe('waiting');
+    await waitFor(() => expect(result.current.stage).toBe('unopened'));
+    expect(result.current.isStalled).toBe(false);
     expect(onCompleted).not.toHaveBeenCalled();
     expect(toastMock).toHaveBeenCalledWith(
       expect.objectContaining({ description: expect.stringContaining('went through') }),
     );
   });
 
-  // Parked with no polling behind it (the purchase was already complete when the modal opened):
+  // Nothing is polling behind this (the purchase was already complete when the modal opened):
   // recheck still has to retry, which it cannot do without a remembered bundle.
   it('retries the completion when Check again is pressed', async () => {
     vi.mocked(LocksController.fetchPaidContent).mockRejectedValue(new Error('down'));
     const { result, onCompleted } = renderPay();
-    await waitFor(() => expect(result.current.isStalled).toBe(true));
+    await waitFor(() => expect(result.current.stage).toBe('unopened'));
 
     vi.mocked(LocksController.fetchPaidContent).mockResolvedValue(unlockedContent);
     const before = vi.mocked(LocksController.fetchPaidContent).mock.calls.length;
@@ -298,6 +299,19 @@ describe('usePayToUnlock (finishing)', () => {
     act(() => result.current.viewContent());
     expect(onCompleted).toHaveBeenCalledWith(unlockedContent);
     expect(vi.mocked(LocksController.fetchPaidContent).mock.calls.length).toBeGreaterThan(before);
+  });
+
+  // Leaving Check again on screen through the lookup invites a second one for the same bundle.
+  it('takes the retry screen away as soon as Check again is pressed', async () => {
+    vi.mocked(LocksController.fetchPaidContent).mockRejectedValue(new Error('down'));
+    const { result } = renderPay();
+    await waitFor(() => expect(result.current.stage).toBe('unopened'));
+
+    // Hangs, so the stage can only have moved from the press itself.
+    vi.mocked(LocksController.fetchPaymentStatus).mockReturnValue(new Promise<TVerificationStatus>(() => {}));
+    act(() => result.current.recheck());
+
+    expect(result.current.stage).toBe('waiting');
   });
 });
 

--- a/src/hooks/usePayToUnlock/usePayToUnlock.test.ts
+++ b/src/hooks/usePayToUnlock/usePayToUnlock.test.ts
@@ -4,6 +4,7 @@ import { LocksController } from '@/controllers/locks/locks';
 import type { LockFile, TUnlockedContent, TVerificationStatus } from '@/services/locks/locks.types';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { POLL_INTERVAL_MS, STALL_AFTER_MS, usePayToUnlock } from './usePayToUnlock';
+import type { TPayToUnlockStage } from './usePayToUnlock.types';
 
 vi.mock('@/controllers/locks/locks', () => ({
   LocksController: {
@@ -317,6 +318,21 @@ describe('usePayToUnlock (waiting)', () => {
       await vi.advanceTimersByTimeAsync(ms);
     });
 
+  /** Arranges the wait so the second lookup hangs, and hands back its release. */
+  const holdOneLookup = (thenAlways: TVerificationStatus) => {
+    let release: (status: TVerificationStatus) => void = () => {};
+    vi.mocked(LocksController.fetchPaymentStatus)
+      .mockResolvedValueOnce('pending')
+      .mockImplementationOnce(
+        () =>
+          new Promise((r) => {
+            release = r;
+          }),
+      )
+      .mockResolvedValue(thenAlways);
+    return (status: TVerificationStatus) => release(status);
+  };
+
   it('stops polling and shows the paid confirmation when a poll sees the payment complete', async () => {
     vi.mocked(LocksController.fetchPaymentStatus).mockResolvedValueOnce('pending').mockResolvedValueOnce('completed');
 
@@ -440,6 +456,101 @@ describe('usePayToUnlock (waiting)', () => {
     });
     expect(result.current.isStalled).toBe(false);
     expect(statusCalls()).toBeGreaterThan(lookupsWhenParked + 1);
+  });
+
+  // The tab coming back from Bitkit right as the throttled timer fires is the normal case, not a
+  // race: `timer` already holds the fired id, so nothing cancels the lookup that is still awaiting
+  // the server. A second loop from here means every symptom below.
+  describe('tab returns while a lookup is in flight', () => {
+    // Drives the wait to the moment the timer-fired lookup is awaiting the server, then returns
+    // the tab to the foreground.
+    const returnToTabMidLookup = async () => {
+      await advance(POLL_INTERVAL_MS);
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+        await vi.advanceTimersByTimeAsync(0);
+      });
+    };
+
+    it('keeps one lookup per interval', async () => {
+      const release = holdOneLookup('pending');
+
+      const { result } = renderPay();
+      await advance(0);
+      expect(result.current.stage).toBe('waiting');
+
+      await returnToTabMidLookup();
+      release('pending');
+      await advance(0);
+
+      const lookupsBefore = statusCalls();
+      await advance(POLL_INTERVAL_MS);
+      expect(statusCalls()).toBe(lookupsBefore + 1);
+    });
+
+    // Two chains both seeing `completed` mint two credentials and download the same post twice,
+    // and the second `finish()` drags the confirmation back through its own waiting stage.
+    it('finishes the completed payment once', async () => {
+      const release = holdOneLookup('completed');
+      const stages: TPayToUnlockStage[] = [];
+
+      const { result } = renderHook(() => {
+        const value = usePayToUnlock({ open: true, lockUrl: LOCK_URL, lockFile, onCompleted: vi.fn(), onPurchased });
+        stages.push(value.stage);
+        return value;
+      });
+      await advance(0);
+      expect(result.current.stage).toBe('waiting');
+
+      await returnToTabMidLookup();
+      release('completed');
+      await advance(0);
+
+      expect(result.current.stage).toBe('paid');
+      expect(LocksController.fetchPaidContent).toHaveBeenCalledTimes(1);
+      // The confirmation is final: no flip back to the spinner once it is on screen.
+      expect(stages.slice(stages.indexOf('paid'))).not.toContain('waiting');
+    });
+
+    it('reports a failed payment once', async () => {
+      const release = holdOneLookup('failed');
+
+      const { result } = renderPay();
+      await advance(0);
+      expect(result.current.stage).toBe('waiting');
+
+      await returnToTabMidLookup();
+      release('failed');
+      await advance(0);
+
+      expect(result.current.stage).toBe('pay');
+      expect(toastMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // Check again retires the running loop, but `stop()` cannot cancel a lookup that is already
+  // awaiting the server — only the per-loop flag can. Today the button hides the moment the retry
+  // starts, so this is the guard behind the restart path rather than a reachable screen.
+  it('leaves the loop Check again retired unable to schedule or finish', async () => {
+    const release = holdOneLookup('pending');
+
+    const { result } = renderPay();
+    await advance(0);
+    expect(result.current.stage).toBe('waiting');
+
+    // The retired loop's lookup is awaiting the server at the moment it is replaced.
+    await advance(POLL_INTERVAL_MS);
+    act(() => result.current.recheck());
+    await advance(0);
+
+    release('completed');
+    await advance(0);
+    expect(LocksController.fetchPaidContent).not.toHaveBeenCalled();
+    expect(result.current.stage).toBe('waiting');
+
+    const lookupsBefore = statusCalls();
+    await advance(POLL_INTERVAL_MS);
+    expect(statusCalls()).toBe(lookupsBefore + 1);
   });
 
   it('goes quiet when the modal closes mid-wait', async () => {

--- a/src/hooks/usePayToUnlock/usePayToUnlock.ts
+++ b/src/hooks/usePayToUnlock/usePayToUnlock.ts
@@ -1,0 +1,271 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { LocksController } from '@/controllers/locks/locks';
+import { toast } from '@/molecules/Toaster/toast';
+import { LockContentParser } from '@/pipes/locks/locks.parser';
+import type { TUnlockedContent, TVerificationStatus } from '@/services/locks/locks.types';
+import { useAuthStore } from '@/stores/auth/auth.store';
+import type { TPayToUnlockStage, UsePayToUnlockParams, UsePayToUnlockResult } from './usePayToUnlock.types';
+
+/** Exported for tests (they advance fake timers by exactly these). */
+export const POLL_INTERVAL_MS = 3000;
+/**
+ * When to park the polling, on the wall clock — a frozen background tab skips attempts, so
+ * counting them would under-measure. Parking is NOT failing: the purchase and its stored bundle
+ * id survive, the screen stays on "awaiting payment", and the tab becoming visible again grants
+ * a fresh window. There is no server-side deadline to align with.
+ */
+export const STALL_AFTER_MS = 3 * 60 * 1000;
+
+/** The 502 wraps both "wallet not ready" and "Paykit down" — the server cannot tell us which. */
+const SUBMIT_FAILED_TOAST = 'The payment could not be started. Check that Bitkit is set up, or try again later.';
+const FINISH_FAILED_TOAST =
+  'Your payment went through, but the content could not be opened. Nothing is lost — try again.';
+
+/**
+ * State machine behind the Pay to Unlock modal.
+ *
+ * Opening resolves the saved bundle id first — the server is the source of truth for what that
+ * id means (no status → the submission never landed → offer Pay with the SAME id). The button is
+ * the start of the payment: nothing is submitted by merely opening or closing the modal.
+ *
+ * Waiting polls on a timer, re-checks immediately when the tab becomes visible again (background
+ * tabs get frozen while the reader pays in Bitkit), and parks on a wall-clock deadline without
+ * failing the purchase.
+ */
+export function usePayToUnlock({
+  open,
+  lockUrl,
+  lockFile,
+  onCompleted,
+  onPurchased,
+}: UsePayToUnlockParams): UsePayToUnlockResult {
+  const [stage, setStage] = useState<TPayToUnlockStage>('checking');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  // Surfaced because a reader who never leaves the tab gets no visibility event, so without a
+  // manual way back the wait would be stuck for good.
+  const [isStalled, setIsStalled] = useState(false);
+  const readerPubky = useAuthStore((state) => state.currentUserPubky);
+  // `currentUserPubky` is persisted and rehydrates first; the session is rebuilt asynchronously.
+  // Without it the bundle id read silently reports "none" (the homeserver service refuses
+  // sessionless reads with null), which would fail OPEN — so everything waits for the session.
+  const session = useAuthStore((state) => state.session);
+
+  // A saved id whose payment ended failed/expired — the one id the submit re-read must NOT reuse.
+  // Deliberately not "null means dead": a concurrent tab's fresh id must survive the re-read.
+  const deadBundleId = useRef<string | null>(null);
+  // One generation per modal opening: every async continuation checks it, so a closed (or
+  // reopened) modal can't apply stale results or keep polling.
+  const generation = useRef(0);
+  // The active poll loop's teardown (timer + visibility listener) — replaced on every loop start,
+  // called on close/unmount. The generation makes a leaked loop inert; this makes it absent.
+  const stopPolling = useRef<(() => void) | null>(null);
+  // The bundle the current wait belongs to, so a manual re-check knows what to look up.
+  const waitingBundleId = useRef<string | null>(null);
+  // Held behind the paid confirmation screen until the reader explicitly chooses View Content.
+  const completedContent = useRef<TUnlockedContent | null>(null);
+  // A ref, not the state flag: two clicks in the same tick both read the pre-render state and
+  // would each mint an id and submit — the shape of a double payment.
+  const submitting = useRef(false);
+
+  /**
+   * Credential and guarded read together — a read failure has to reach the same retry and the same
+   * parked state as a credential failure, or the reader is left on a spinner with nothing to press.
+   */
+  const finish = async (gen: number, bundleId: string) => {
+    if (!lockFile) return;
+    // The waiting screen owns this bundle from here on, even when the purchase was already
+    // complete on open (no polling ran), so "Check again" has something to retry.
+    waitingBundleId.current = bundleId;
+    setStage('waiting');
+
+    let content: TUnlockedContent;
+    try {
+      content = await LocksController.fetchPaidContent({ lockFile, bundleId });
+    } catch {
+      // Already reported by the Err factory. Parked, not lost: the purchase stands and
+      // "Check again" runs this path again.
+      if (generation.current !== gen) return;
+      setIsStalled(true);
+      toast({ variant: 'error', description: FINISH_FAILED_TOAST });
+      return;
+    }
+    if (generation.current !== gen) return;
+    completedContent.current = content;
+    setIsStalled(false);
+    setStage('paid');
+  };
+
+  const applyStatus = (gen: number, bundleId: string, status: TVerificationStatus): boolean => {
+    if (status === 'completed') {
+      void finish(gen, bundleId);
+      return false;
+    }
+    if (status === 'failed' || status === 'expired') {
+      // Unretryable: the next submit mints a fresh id (the saved one is overwritten before it).
+      deadBundleId.current = bundleId;
+      toast({ variant: 'error', description: `The payment ${status}. You can try again.` });
+      setStage('pay');
+      return false;
+    }
+    setStage('waiting');
+    return true;
+  };
+
+  const startPolling = (gen: number, bundleId: string, lookupNow = false) => {
+    if (!lockFile) return;
+    waitingBundleId.current = bundleId;
+    setIsStalled(false);
+    let windowStartedAt = Date.now();
+    let timer: number | null = null;
+
+    const poll = async () => {
+      if (generation.current !== gen) return;
+      let status: TVerificationStatus | null;
+      try {
+        status = await LocksController.fetchPaymentStatus({ lockFile, bundleId });
+      } catch {
+        // Already reported by the Err factory; a lookup blip is not worth surfacing mid-wait.
+        schedule();
+        return;
+      }
+      if (generation.current !== gen) return;
+      // A null mid-wait would mean the server lost the payment; treat like still-pending.
+      if (status && !applyStatus(gen, bundleId, status)) {
+        stop();
+        return;
+      }
+      schedule();
+    };
+
+    const schedule = () => {
+      if (generation.current !== gen) return;
+      if (Date.now() - windowStartedAt > STALL_AFTER_MS) {
+        setIsStalled(true);
+        return;
+      }
+      timer = window.setTimeout(() => void poll(), POLL_INTERVAL_MS);
+    };
+
+    // The reader pays in Bitkit, so this tab is backgrounded (timers frozen) for most of the
+    // wait. Returning is the real signal: look up immediately and, if the loop had parked,
+    // grant a fresh wall-clock window so it truly resumes.
+    const onVisible = () => {
+      if (document.visibilityState !== 'visible' || generation.current !== gen) return;
+      if (timer !== null) window.clearTimeout(timer);
+      windowStartedAt = Date.now();
+      setIsStalled(false);
+      void poll();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+
+    // After submit/open the caller has just received a status, so the first lookup can wait one
+    // interval; Check again is the reader asking for one now.
+    if (lookupNow) void poll();
+    else schedule();
+
+    const stop = () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      if (timer !== null) window.clearTimeout(timer);
+      if (stopPolling.current === stop) stopPolling.current = null;
+    };
+    stopPolling.current?.();
+    stopPolling.current = stop;
+  };
+
+  // Modal opened: resolve the saved bundle id, then route. Closed: bump the generation so every
+  // pending continuation goes quiet, and tear the poll loop down.
+  useEffect(() => {
+    if (!open || !lockFile || !readerPubky || !session) return;
+    const gen = ++generation.current;
+    setStage('checking');
+    setIsStalled(false);
+    completedContent.current = null;
+    deadBundleId.current = null;
+
+    void (async () => {
+      try {
+        const stored = await LocksController.fetchPurchaseBundleId({ lockUrl, readerPubky });
+        if (generation.current !== gen) return;
+
+        if (stored) {
+          const status = await LocksController.fetchPaymentStatus({ lockFile, bundleId: stored });
+          if (generation.current !== gen) return;
+          if (!status) {
+            // Saved id with no status behind it: the submission never landed. Pay again with the SAME id.
+            setStage('pay');
+            return;
+          }
+          if (applyStatus(gen, stored, status)) startPolling(gen, stored);
+          return;
+        }
+
+        const hasWallet = await LocksController.hasPaykitReceiver(readerPubky);
+        if (generation.current !== gen) return;
+        setStage(hasWallet ? 'pay' : 'install');
+      } catch {
+        // Includes an unreadable saved bundle id: minting a fresh one could pay twice, so no Pay
+        // button. Already reported by the Err factory that threw it.
+        if (generation.current !== gen) return;
+        setStage('blocked');
+      }
+    })();
+
+    return () => {
+      // Deliberate: invalidating the generation IS the cancellation mechanism (not a node ref).
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      generation.current++;
+      stopPolling.current?.();
+      stopPolling.current = null;
+    };
+    // startPolling/applyStatus/toast are stable for one opening; re-running on their identity would restart the flow.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, lockUrl, lockFile, readerPubky, session]);
+
+  const submit = () => {
+    if (submitting.current || !lockFile || !readerPubky || !session) return;
+    const gen = generation.current;
+    submitting.current = true;
+    setIsSubmitting(true);
+
+    void (async () => {
+      try {
+        const { bundleId, status } = await LocksController.startPayment({
+          lockFile,
+          lockUrl,
+          readerPubky,
+          rejectBundleId: deadBundleId.current,
+        });
+        const lockId = LockContentParser.lockIdFromUrl(lockUrl);
+        if (lockId) onPurchased(lockId);
+        if (generation.current !== gen) return;
+        if (applyStatus(gen, bundleId, status)) startPolling(gen, bundleId);
+      } catch {
+        // TODO:[Locks] a wallet that has no receiver and Paykit being down both arrive as the same
+        // 502 (`paykit_invoice_creation_failed`); ask the locks side for a distinct code so this
+        // toast can say which one it was. Already reported by the Err factory.
+        if (generation.current !== gen) return;
+        toast({ variant: 'error', description: SUBMIT_FAILED_TOAST });
+      } finally {
+        submitting.current = false;
+        setIsSubmitting(false);
+      }
+    })();
+  };
+
+  const recheck = () => {
+    const bundleId = waitingBundleId.current;
+    if (!bundleId) return;
+    startPolling(generation.current, bundleId, true);
+  };
+
+  const viewContent = () => {
+    const content = completedContent.current;
+    if (!content) return;
+    completedContent.current = null;
+    onCompleted(content);
+  };
+
+  return { stage, isStalled, isSubmitting, submit, recheck, viewContent };
+}

--- a/src/hooks/usePayToUnlock/usePayToUnlock.ts
+++ b/src/hooks/usePayToUnlock/usePayToUnlock.ts
@@ -84,10 +84,10 @@ export function usePayToUnlock({
     try {
       content = await LocksController.fetchPaidContent({ lockFile, bundleId });
     } catch {
-      // Already reported by the Err factory. Parked, not lost: the purchase stands and
-      // "Check again" runs this path again.
+      // Already reported by the Err factory. The payment stands — only the download failed — so
+      // this gets its own stage rather than the waiting copy that asks the reader to go pay.
       if (generation.current !== gen) return;
-      setIsStalled(true);
+      setStage('unopened');
       toast({ variant: 'error', description: FINISH_FAILED_TOAST });
       return;
     }
@@ -272,6 +272,9 @@ export function usePayToUnlock({
   const recheck = () => {
     const bundleId = waitingBundleId.current;
     if (!bundleId) return;
+    // Take the retry screen away before the lookup goes out, so Check again cannot be pressed
+    // again while it is still running.
+    setStage('waiting');
     startPolling(generation.current, bundleId, true);
   };
 

--- a/src/hooks/usePayToUnlock/usePayToUnlock.ts
+++ b/src/hooks/usePayToUnlock/usePayToUnlock.ts
@@ -119,18 +119,28 @@ export function usePayToUnlock({
     setIsStalled(false);
     let windowStartedAt = Date.now();
     let timer: number | null = null;
+    // One opening can start several loops (Check again, a re-submit), so `generation` cannot tell
+    // them apart, and clearing `timer` does nothing to a lookup that is already awaiting the
+    // server. This is what makes a superseded loop's continuations inert.
+    let active = true;
+    // A fired timer leaves `timer` holding its spent id, so this flag is the only way to see that
+    // a lookup is still out.
+    let inFlight = false;
 
     const poll = async () => {
-      if (generation.current !== gen) return;
+      if (!active || generation.current !== gen) return;
       let status: TVerificationStatus | null;
+      inFlight = true;
       try {
         status = await LocksController.fetchPaymentStatus({ lockFile, bundleId });
       } catch {
         // Already reported by the Err factory; a lookup blip is not worth surfacing mid-wait.
+        inFlight = false;
         schedule();
         return;
       }
-      if (generation.current !== gen) return;
+      inFlight = false;
+      if (!active || generation.current !== gen) return;
       // A null mid-wait would mean the server lost the payment; treat like still-pending.
       if (status && !applyStatus(gen, bundleId, status)) {
         stop();
@@ -140,7 +150,7 @@ export function usePayToUnlock({
     };
 
     const schedule = () => {
-      if (generation.current !== gen) return;
+      if (!active || generation.current !== gen) return;
       if (Date.now() - windowStartedAt > STALL_AFTER_MS) {
         setIsStalled(true);
         return;
@@ -152,26 +162,31 @@ export function usePayToUnlock({
     // wait. Returning is the real signal: look up immediately and, if the loop had parked,
     // grant a fresh wall-clock window so it truly resumes.
     const onVisible = () => {
-      if (document.visibilityState !== 'visible' || generation.current !== gen) return;
-      if (timer !== null) window.clearTimeout(timer);
+      if (document.visibilityState !== 'visible' || !active || generation.current !== gen) return;
       windowStartedAt = Date.now();
       setIsStalled(false);
+      // The lookup already out will schedule the next one. Starting a second here forks the loop
+      // into two chains that both poll, both finish, and that `stop()` can only half tear down.
+      if (inFlight) return;
+      if (timer !== null) window.clearTimeout(timer);
       void poll();
     };
     document.addEventListener('visibilitychange', onVisible);
+
+    const stop = () => {
+      active = false;
+      document.removeEventListener('visibilitychange', onVisible);
+      if (timer !== null) window.clearTimeout(timer);
+      if (stopPolling.current === stop) stopPolling.current = null;
+    };
+    // Retire the previous loop before this one starts, so only one is ever live.
+    stopPolling.current?.();
+    stopPolling.current = stop;
 
     // After submit/open the caller has just received a status, so the first lookup can wait one
     // interval; Check again is the reader asking for one now.
     if (lookupNow) void poll();
     else schedule();
-
-    const stop = () => {
-      document.removeEventListener('visibilitychange', onVisible);
-      if (timer !== null) window.clearTimeout(timer);
-      if (stopPolling.current === stop) stopPolling.current = null;
-    };
-    stopPolling.current?.();
-    stopPolling.current = stop;
   };
 
   // Modal opened: resolve the saved bundle id, then route. Closed: bump the generation so every

--- a/src/hooks/usePayToUnlock/usePayToUnlock.types.ts
+++ b/src/hooks/usePayToUnlock/usePayToUnlock.types.ts
@@ -1,0 +1,37 @@
+import type { LockFile, TUnlockedContent } from '@/services/locks/locks.types';
+
+/**
+ * What the Pay to Unlock modal shows. Two of these exist for safety rather than display:
+ * `checking` renders no button until the saved bundle id is resolved, so one already in flight
+ * can never look payable again, and `blocked` is where an unreadable saved bundle id lands — paying again
+ * could mean paying twice, so it is not offered.
+ */
+export type TPayToUnlockStage = 'checking' | 'pay' | 'install' | 'waiting' | 'paid' | 'blocked';
+
+export interface UsePayToUnlockParams {
+  /** The modal's open state; closed keeps the hook idle (no requests, no polling). */
+  open: boolean;
+  /** The post's public `lock.json` URL. */
+  lockUrl: string;
+  /** The fetched lock file; null keeps the hook idle. */
+  lockFile: LockFile | null;
+  /** Called when the reader chooses View Content after the paid content has been read. */
+  onCompleted: (content: TUnlockedContent) => void;
+  /** Called with the lock id as soon as a purchase is stored, so other cards see it this session. */
+  onPurchased: (lockId: string) => void;
+}
+
+export interface UsePayToUnlockResult {
+  stage: TPayToUnlockStage;
+  /** The wait gave up on its own; only `recheck` moves it forward from here. */
+  isStalled: boolean;
+  /** True from button press until the submission settles (locks the button). */
+  isSubmitting: boolean;
+  /** The `pay` / `install` primary action. Reuses a stored bundle id when there is one — minting a
+   *  second id for the same lock is how a reader ends up paying twice. */
+  submit: () => void;
+  /** Resume a parked wait. The purchase was never abandoned, so this only restarts the polling. */
+  recheck: () => void;
+  /** Reveals content already downloaded for the paid confirmation screen. */
+  viewContent: () => void;
+}

--- a/src/hooks/usePayToUnlock/usePayToUnlock.types.ts
+++ b/src/hooks/usePayToUnlock/usePayToUnlock.types.ts
@@ -4,9 +4,10 @@ import type { LockFile, TUnlockedContent } from '@/services/locks/locks.types';
  * What the Pay to Unlock modal shows. Two of these exist for safety rather than display:
  * `checking` renders no button until the saved bundle id is resolved, so one already in flight
  * can never look payable again, and `blocked` is where an unreadable saved bundle id lands — paying again
- * could mean paying twice, so it is not offered.
+ * could mean paying twice, so it is not offered. `unopened` is its own stage because the payment
+ * succeeded there and only the content download failed: the reader must never be told to go pay.
  */
-export type TPayToUnlockStage = 'checking' | 'pay' | 'install' | 'waiting' | 'paid' | 'blocked';
+export type TPayToUnlockStage = 'checking' | 'pay' | 'install' | 'waiting' | 'paid' | 'unopened' | 'blocked';
 
 export interface UsePayToUnlockParams {
   /** The modal's open state; closed keeps the hook idle (no requests, no polling). */

--- a/src/hooks/usePurchaseResume/usePurchaseResume.test.ts
+++ b/src/hooks/usePurchaseResume/usePurchaseResume.test.ts
@@ -1,0 +1,154 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LocksController } from '@/controllers/locks/locks';
+import type { LockFile, TUnlockedContent } from '@/services/locks/locks.types';
+import { asOpaque } from '@/test-utils/type-assertions';
+import { usePurchaseResume } from './usePurchaseResume';
+
+vi.mock('@/controllers/locks/locks', () => ({
+  LocksController: {
+    fetchPaidContentIfCompleted: vi.fn(),
+  },
+}));
+const authState = vi.hoisted(() => ({ currentUserPubky: 'reader1' as string | null, session: {} as object | null }));
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: (selector: (s: typeof authState) => unknown) => selector(authState),
+}));
+
+const lockFile = asOpaque<LockFile>({ creator: 'pubkybob' });
+const LOCK_URL = 'pubky://pubkybob/pub/locks.app/LOCK1.json';
+const content = asOpaque<TUnlockedContent>({
+  post: { content: 'paid', kind: 'short', attachments: null },
+  attachments: [],
+});
+
+/** Hands the resolver back so a test can finish the read after the hook has moved on. */
+const deferredRead = () => {
+  let resolve: (content: TUnlockedContent | null) => void = () => {};
+  vi.mocked(LocksController.fetchPaidContentIfCompleted).mockReturnValue(new Promise((r) => (resolve = r)));
+  return resolve;
+};
+
+const renderResume = (isPurchased = true, onResumed = vi.fn(), hasContent = false, isResolvingContent = false) => ({
+  onResumed,
+  ...renderHook(
+    ({ purchased, resolving, content }: { purchased: boolean; resolving: boolean; content: boolean }) =>
+      usePurchaseResume({
+        lock: LOCK_URL,
+        lockFile,
+        isPurchased: purchased,
+        hasContent: content,
+        isResolvingContent: resolving,
+        onResumed,
+      }),
+    { initialProps: { purchased: isPurchased, resolving: isResolvingContent, content: hasContent } },
+  ),
+});
+
+describe('usePurchaseResume', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.currentUserPubky = 'reader1';
+    authState.session = {};
+    vi.mocked(LocksController.fetchPaidContentIfCompleted).mockResolvedValue(content);
+  });
+
+  // The whole point: the reader paid, left, and the post would otherwise still say Unlock.
+  it('reads and hands back content for a purchase that completed while the reader was away', async () => {
+    const { onResumed } = renderResume();
+
+    await waitFor(() => expect(onResumed).toHaveBeenCalledWith(content));
+    expect(LocksController.fetchPaidContentIfCompleted).toHaveBeenCalledWith({
+      lockFile,
+      lockUrl: LOCK_URL,
+      readerPubky: 'reader1',
+    });
+  });
+
+  // The purchases listing and the lock file arrive independently. When the listing lands second,
+  // the answer flips to true and the recovery still has to start.
+  it('starts once the purchases listing lands after the lock file', async () => {
+    const { rerender } = renderResume(false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(LocksController.fetchPaidContentIfCompleted).not.toHaveBeenCalled();
+
+    rerender({ purchased: true, resolving: false, content: false });
+    await waitFor(() => expect(LocksController.fetchPaidContentIfCompleted).toHaveBeenCalled());
+  });
+
+  // A slow replica read must not read as "never unlocked" — otherwise a slow connection pays the
+  // download cost twice for content the reader already has.
+  it('waits for the replica read before deciding anything is missing', async () => {
+    const { rerender } = renderResume(true, vi.fn(), false, true);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(LocksController.fetchPaidContentIfCompleted).not.toHaveBeenCalled();
+
+    // The read finishes and the replica was there all along.
+    rerender({ purchased: true, resolving: false, content: true });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(LocksController.fetchPaidContentIfCompleted).not.toHaveBeenCalled();
+
+    // The read finishes with nothing: now there is something to recover.
+    rerender({ purchased: true, resolving: false, content: false });
+    await waitFor(() => expect(LocksController.fetchPaidContentIfCompleted).toHaveBeenCalled());
+  });
+
+  // Purchase entries are kept forever, so this is what stops an old unlock being re-downloaded
+  // (and re-replicated) on every mount.
+  it('does nothing when the content already renders from the replica', async () => {
+    renderResume(true, vi.fn(), true);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(LocksController.fetchPaidContentIfCompleted).not.toHaveBeenCalled();
+  });
+
+  // Nothing to recover yet (no saved id, or still pending): the modal owns that wait.
+  it('does nothing when there is nothing to recover', async () => {
+    vi.mocked(LocksController.fetchPaidContentIfCompleted).mockResolvedValue(null);
+    const { onResumed } = renderResume();
+
+    await waitFor(() => expect(LocksController.fetchPaidContentIfCompleted).toHaveBeenCalled());
+    expect(onResumed).not.toHaveBeenCalled();
+  });
+
+  it('waits for the restored session before reading the reader storage', async () => {
+    authState.session = null;
+    renderResume();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(LocksController.fetchPaidContentIfCompleted).not.toHaveBeenCalled();
+  });
+
+  // The reader still has the modal, and the next mount of the post tries again.
+  it('stays quiet when the completion fails', async () => {
+    vi.mocked(LocksController.fetchPaidContentIfCompleted).mockRejectedValue(new Error('down'));
+    const { onResumed } = renderResume();
+
+    await waitFor(() => expect(LocksController.fetchPaidContentIfCompleted).toHaveBeenCalled());
+    expect(onResumed).not.toHaveBeenCalled();
+  });
+
+  it('drops a late result after unmount', async () => {
+    const resolveRead = deferredRead();
+    const { onResumed, unmount } = renderResume();
+    await waitFor(() => expect(LocksController.fetchPaidContentIfCompleted).toHaveBeenCalled());
+
+    unmount();
+    resolveRead(content);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onResumed).not.toHaveBeenCalled();
+  });
+
+  // The replica read and the recovery run side by side; the replica landing first must win.
+  it('drops a late result once the replica arrived', async () => {
+    const resolveRead = deferredRead();
+    const { onResumed, rerender } = renderResume();
+    await waitFor(() => expect(LocksController.fetchPaidContentIfCompleted).toHaveBeenCalled());
+
+    rerender({ purchased: true, resolving: false, content: true });
+    resolveRead(content);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onResumed).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePurchaseResume/usePurchaseResume.ts
+++ b/src/hooks/usePurchaseResume/usePurchaseResume.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+import { LocksController } from '@/controllers/locks/locks';
+import { LockContentParser } from '@/pipes/locks/locks.parser';
+import { useAuthStore } from '@/stores/auth/auth.store';
+import type { UsePurchaseResumeParams } from './usePurchaseResume.types';
+
+/**
+ * Finishes a purchase the reader already paid for but never received.
+ *
+ * The payment completes on the server whether or not the browser is watching, so a reader who
+ * closed the tab mid-wait would come back to a post still offering Unlock over content they own.
+ *
+ * Never spends money: it reads the saved bundle id, asks the server its status, and downloads.
+ * No branch here mints an id or submits a proof.
+ */
+export function usePurchaseResume({
+  lock,
+  lockFile,
+  isPurchased,
+  hasContent,
+  isResolvingContent,
+  onResumed,
+}: UsePurchaseResumeParams): void {
+  const readerPubky = useAuthStore((state) => state.currentUserPubky);
+  const session = useAuthStore((state) => state.session);
+
+  useEffect(() => {
+    const lockId = lock ? LockContentParser.lockIdFromUrl(lock) : null;
+    if (!lock || !lockFile || !lockId || !readerPubky || !session) return;
+    // Waiting out the replica read is what keeps a slow connection from looking like "never
+    // unlocked" and paying the download cost twice.
+    if (isResolvingContent || hasContent || !isPurchased) return;
+
+    let cancelled = false;
+
+    // Failures are already reported by the Err factory; the next mount of this post tries again.
+    void LocksController.fetchPaidContentIfCompleted({ lockFile, lockUrl: lock, readerPubky })
+      .catch(() => null)
+      .then((content) => {
+        if (content && !cancelled) onResumed(content);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // `onResumed` changes identity every render; the inputs that decide a run are the deps above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lock, lockFile, readerPubky, session, isPurchased, hasContent, isResolvingContent]);
+}

--- a/src/hooks/usePurchaseResume/usePurchaseResume.types.ts
+++ b/src/hooks/usePurchaseResume/usePurchaseResume.types.ts
@@ -1,0 +1,16 @@
+import type { LockFile, TUnlockedContent } from '@/services/locks/locks.types';
+
+export interface UsePurchaseResumeParams {
+  /** The post's public `lock.json` URL; null keeps the hook idle. */
+  lock: string | null | undefined;
+  /** The fetched lock file; null keeps the hook idle. */
+  lockFile: LockFile | null;
+  /** Whether the reader has a bundle id saved for this lock. A boolean so the effect re-runs when the listing lands after the lock file. */
+  isPurchased: boolean;
+  /** Content already on screen from the replica; saved bundle ids are kept forever, so this stops a re-download on every mount. */
+  hasContent: boolean;
+  /** Replica read still in flight, so `hasContent: false` only means "not known yet". */
+  isResolvingContent: boolean;
+  /** Called with the recovered content once it has been read. */
+  onResumed: (content: TUnlockedContent) => void;
+}

--- a/src/hooks/usePurchasedLocks/usePurchasedLocks.test.ts
+++ b/src/hooks/usePurchasedLocks/usePurchasedLocks.test.ts
@@ -1,0 +1,162 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LocksController } from '@/controllers/locks/locks';
+import { usePurchasedLocks } from './usePurchasedLocks';
+
+vi.mock('@/controllers/locks/locks', () => ({
+  LocksController: { fetchPurchasedLockIds: vi.fn() },
+}));
+
+const authState = vi.hoisted(() => ({
+  currentUserPubky: 'reader1' as string | null,
+  session: { pubky: 'reader1' } as { pubky: string } | null,
+}));
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: (selector: (s: typeof authState) => unknown) => selector(authState),
+}));
+
+describe('usePurchasedLocks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // A different reader each test, so the module-level purchasedIdsByReader (one listing per reader) can't leak
+    // an answer from the previous one.
+    authState.currentUserPubky = `reader-${Math.random().toString(36).slice(2)}`;
+    authState.session = { pubky: authState.currentUserPubky };
+    vi.mocked(LocksController.fetchPurchasedLockIds).mockResolvedValue(['lock1']);
+  });
+
+  it('answers from a single listing rather than a request per lock', async () => {
+    const { result } = renderHook(() => usePurchasedLocks({ enabled: true }));
+
+    await waitFor(() => expect(result.current.hasPurchase('lock1')).toBe(true));
+    expect(result.current.hasPurchase('lock2')).toBe(false);
+    expect(LocksController.fetchPurchasedLockIds).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the listing across mounts for the same reader', async () => {
+    const first = renderHook(() => usePurchasedLocks({ enabled: true }));
+    await waitFor(() => expect(first.result.current.hasPurchase('lock1')).toBe(true));
+
+    const second = renderHook(() => usePurchasedLocks({ enabled: true }));
+    await waitFor(() => expect(second.result.current.hasPurchase('lock1')).toBe(true));
+    expect(LocksController.fetchPurchasedLockIds).toHaveBeenCalledTimes(1);
+  });
+
+  // A purchase made in this session must be visible before any re-listing.
+  it('counts a lock marked purchased this session', async () => {
+    const { result } = renderHook(() => usePurchasedLocks({ enabled: true }));
+    await waitFor(() => expect(result.current.hasPurchase('lock1')).toBe(true));
+
+    act(() => result.current.markPurchased('lock-new'));
+    await waitFor(() => expect(result.current.hasPurchase('lock-new')).toBe(true));
+  });
+
+  // The listing is shared by every card on the page. Replacing it while still in flight would let
+  // the server answer land afterwards and drop the purchase just made.
+  it('keeps a purchase marked while the listing is still in flight', async () => {
+    let resolveListing: (ids: string[]) => void = () => {};
+    vi.mocked(LocksController.fetchPurchasedLockIds).mockReturnValue(
+      new Promise((resolve) => {
+        resolveListing = resolve;
+      }),
+    );
+    const { result } = renderHook(() => usePurchasedLocks({ enabled: true }));
+
+    act(() => result.current.markPurchased('lock-new'));
+    await act(async () => resolveListing(['lock1']));
+
+    await waitFor(() => expect(result.current.hasPurchase('lock1')).toBe(true));
+    expect(result.current.hasPurchase('lock-new')).toBe(true);
+  });
+
+  it('reports nothing purchased when the listing fails, without throwing', async () => {
+    vi.mocked(LocksController.fetchPurchasedLockIds).mockRejectedValue(new Error('offline'));
+    const { result } = renderHook(() => usePurchasedLocks({ enabled: true }));
+
+    await waitFor(() => expect(LocksController.fetchPurchasedLockIds).toHaveBeenCalled());
+    expect(result.current.hasPurchase('lock1')).toBe(false);
+  });
+
+  // Otherwise the purchase is invisible until a reload, and the recovery path cannot pick it up.
+  it('still counts a purchase marked after a failed listing', async () => {
+    vi.mocked(LocksController.fetchPurchasedLockIds).mockRejectedValue(new Error('offline'));
+    const { result } = renderHook(() => usePurchasedLocks({ enabled: true }));
+    await waitFor(() => expect(LocksController.fetchPurchasedLockIds).toHaveBeenCalled());
+
+    act(() => result.current.markPurchased('lock-new'));
+    await waitFor(() => expect(result.current.hasPurchase('lock-new')).toBe(true));
+  });
+
+  it('lists nothing while disabled', () => {
+    renderHook(() => usePurchasedLocks({ enabled: false }));
+
+    expect(LocksController.fetchPurchasedLockIds).not.toHaveBeenCalled();
+  });
+
+  it('stays idle for a signed-out reader', () => {
+    authState.currentUserPubky = null;
+    authState.session = null;
+    renderHook(() => usePurchasedLocks({ enabled: true }));
+
+    expect(LocksController.fetchPurchasedLockIds).not.toHaveBeenCalled();
+  });
+
+  // The pubky rehydrates before the session; listing without one reads `/priv` unauthenticated.
+  it('waits for the session before listing', async () => {
+    authState.session = null;
+    const { rerender, result } = renderHook(() => usePurchasedLocks({ enabled: true }));
+    expect(LocksController.fetchPurchasedLockIds).not.toHaveBeenCalled();
+
+    authState.session = { pubky: authState.currentUserPubky as string };
+    rerender();
+
+    await waitFor(() => expect(result.current.hasPurchase('lock1')).toBe(true));
+    expect(LocksController.fetchPurchasedLockIds).toHaveBeenCalledTimes(1);
+  });
+
+  // A failed listing must not be cached as "nothing purchased" for the rest of the page load.
+  it('lists again on the next mount after a failure', async () => {
+    vi.mocked(LocksController.fetchPurchasedLockIds).mockRejectedValueOnce(new Error('offline'));
+    const first = renderHook(() => usePurchasedLocks({ enabled: true }));
+    await waitFor(() => expect(LocksController.fetchPurchasedLockIds).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    first.unmount();
+
+    vi.mocked(LocksController.fetchPurchasedLockIds).mockResolvedValue(['lock1']);
+    const second = renderHook(() => usePurchasedLocks({ enabled: true }));
+
+    await waitFor(() => expect(second.result.current.hasPurchase('lock1')).toBe(true));
+    expect(LocksController.fetchPurchasedLockIds).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-lists for a different reader and does not inherit the previous ids', async () => {
+    const { result, rerender } = renderHook(() => usePurchasedLocks({ enabled: true }));
+    await waitFor(() => expect(result.current.hasPurchase('lock1')).toBe(true));
+
+    authState.currentUserPubky = `reader-${Math.random().toString(36).slice(2)}`;
+    authState.session = { pubky: authState.currentUserPubky };
+    vi.mocked(LocksController.fetchPurchasedLockIds).mockResolvedValue(['lock2']);
+    rerender();
+
+    await waitFor(() => expect(result.current.hasPurchase('lock2')).toBe(true));
+    expect(result.current.hasPurchase('lock1')).toBe(false);
+    expect(LocksController.fetchPurchasedLockIds).toHaveBeenCalledTimes(2);
+  });
+
+  it('two cards mounting at once share one in-flight listing', async () => {
+    let resolveListing: (ids: string[]) => void = () => {};
+    vi.mocked(LocksController.fetchPurchasedLockIds).mockReturnValue(
+      new Promise((resolve) => {
+        resolveListing = resolve;
+      }),
+    );
+    const first = renderHook(() => usePurchasedLocks({ enabled: true }));
+    const second = renderHook(() => usePurchasedLocks({ enabled: true }));
+
+    await act(async () => resolveListing(['lock1']));
+
+    await waitFor(() => expect(first.result.current.hasPurchase('lock1')).toBe(true));
+    await waitFor(() => expect(second.result.current.hasPurchase('lock1')).toBe(true));
+    expect(LocksController.fetchPurchasedLockIds).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/usePurchasedLocks/usePurchasedLocks.ts
+++ b/src/hooks/usePurchasedLocks/usePurchasedLocks.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { LocksController } from '@/controllers/locks/locks';
+import { useAuthStore } from '@/stores/auth/auth.store';
+import type { UsePurchasedLocksParams, UsePurchasedLocksResult } from './usePurchasedLocks.types';
+
+/**
+ * One listing per reader per page load, shared by every lock post on screen. Without it each card
+ * would ask the homeserver whether it has been paid for, which is a request per post in the feed.
+ *
+ * Keyed by reader so signing in as someone else cannot inherit the previous reader's answers.
+ */
+let purchasedIdsByReader: { readerPubky: string; ids: Promise<Set<string>> } | null = null;
+
+function loadPurchasedIds(readerPubky: string): Promise<Set<string>> {
+  if (purchasedIdsByReader?.readerPubky !== readerPubky) {
+    const ids: Promise<Set<string>> = LocksController.fetchPurchasedLockIds({ readerPubky })
+      .then((loaded) => new Set(loaded))
+      // Already reported by the Err factory. Degrade rather than block rendering: the unlock
+      // modal re-reads the saved bundle id itself before it ever offers to pay.
+      .catch(() => {
+        // Let the next mount try again, unless markPurchased already chained onto this listing.
+        if (purchasedIdsByReader?.ids === ids) purchasedIdsByReader = null;
+        return new Set<string>();
+      });
+    purchasedIdsByReader = { readerPubky, ids };
+  }
+  return purchasedIdsByReader.ids;
+}
+
+/** Which locks the signed-in reader has already paid for. */
+export function usePurchasedLocks({ enabled }: UsePurchasedLocksParams): UsePurchasedLocksResult {
+  const readerPubky = useAuthStore((state) => state.currentUserPubky);
+  // `currentUserPubky` is persisted and rehydrates before the session is rebuilt. Listing without
+  // one reads `/priv` unauthenticated, and its 404 would cache "nothing purchased" for the whole
+  // page load — silently disabling the paid-but-never-received recovery.
+  const session = useAuthStore((state) => state.session);
+  const [ids, setIds] = useState<Set<string> | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !readerPubky || !session) {
+      setIds(null);
+      return;
+    }
+    let cancelled = false;
+    void loadPurchasedIds(readerPubky).then((loaded) => {
+      if (!cancelled) setIds(loaded);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, readerPubky, session]);
+
+  const hasPurchase = (lockId: string | null) => Boolean(lockId && ids?.has(lockId));
+
+  /**
+   * The listing was taken before this purchase existed, so without recording it the reader would
+   * have to reload before the recovery path could see it. Chained onto the cached promise rather
+   * than replacing it: a listing still in flight would otherwise land afterwards and drop this id
+   * for every card on the page. A new Set is stored because mutating the cached one changes
+   * nothing on screen.
+   */
+  const markPurchased = (lockId: string) => {
+    // A null purchasedIdsByReader means the listing failed; the purchase still has to be recorded, or the
+    // recovery path cannot pick it up after the modal closes.
+    if (!readerPubky || (purchasedIdsByReader && purchasedIdsByReader.readerPubky !== readerPubky)) return;
+    const merged = (purchasedIdsByReader?.ids ?? Promise.resolve(new Set<string>())).then((loaded) =>
+      new Set(loaded).add(lockId),
+    );
+    purchasedIdsByReader = { readerPubky, ids: merged };
+    void merged.then(setIds);
+  };
+
+  return { hasPurchase, markPurchased };
+}

--- a/src/hooks/usePurchasedLocks/usePurchasedLocks.types.ts
+++ b/src/hooks/usePurchasedLocks/usePurchasedLocks.types.ts
@@ -1,0 +1,11 @@
+export interface UsePurchasedLocksParams {
+  /** False skips the listing, so a password-only feed never reads the purchases directory. */
+  enabled: boolean;
+}
+
+export interface UsePurchasedLocksResult {
+  /** True when this lock already has a bundle id saved on the reader's homeserver. */
+  hasPurchase: (lockId: string | null) => boolean;
+  /** Records a purchase made in this session, so cards see it without a fresh listing. */
+  markPurchased: (lockId: string) => void;
+}

--- a/src/hooks/useUnlockedContent/useUnlockedContent.test.ts
+++ b/src/hooks/useUnlockedContent/useUnlockedContent.test.ts
@@ -22,6 +22,47 @@ vi.mock('@/stores/auth/auth.store', () => ({
 const LOCK_URL = 'pubky://hs/pub/locks.app/lock1.json';
 const content: TUnlockedContent = { post: { content: 'x', kind: 'short', attachments: null }, attachments: [] };
 
+describe('useUnlockedContent (replica resolution)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.currentUserPubky = 'me';
+    authState.session = {};
+  });
+
+  // Callers act on the absence of content (re-downloading a purchase), so "not known yet" has to
+  // be distinguishable from "not there".
+  it('reports resolving until the replica read settles', async () => {
+    let settle: (value: null) => void = () => undefined;
+    vi.mocked(LocksController.fetchReplicatedContent).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useUnlockedContent({ lock: LOCK_URL, lockFile: null, authorId: 'other' }));
+    expect(result.current.isResolvingReplica).toBe(true);
+
+    settle(null);
+    await waitFor(() => expect(result.current.isResolvingReplica).toBe(false));
+  });
+
+  it('stops resolving when the replica read fails', async () => {
+    vi.mocked(LocksController.fetchReplicatedContent).mockRejectedValue(new Error('offline'));
+
+    const { result } = renderHook(() => useUnlockedContent({ lock: LOCK_URL, lockFile: null, authorId: 'other' }));
+
+    await waitFor(() => expect(result.current.isResolvingReplica).toBe(false));
+  });
+
+  // An own post has no replica to wait for, so nothing should be gated on one.
+  it('is not resolving for the reader own post', async () => {
+    const { result } = renderHook(() => useUnlockedContent({ lock: LOCK_URL, lockFile: null, authorId: 'me' }));
+
+    await waitFor(() => expect(result.current.isResolvingReplica).toBe(false));
+    expect(LocksController.fetchReplicatedContent).not.toHaveBeenCalled();
+  });
+});
+
 describe('useUnlockedContent', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/hooks/useUnlockedContent/useUnlockedContent.ts
+++ b/src/hooks/useUnlockedContent/useUnlockedContent.ts
@@ -24,6 +24,9 @@ import type { UseUnlockedContentParams, UseUnlockedContentResult } from './useUn
 export function useUnlockedContent({ lock, lockFile, authorId }: UseUnlockedContentParams): UseUnlockedContentResult {
   const [unlockedPost, setUnlockedPost] = useState<GuardedPost | null>(null);
   const [media, setMedia] = useState<AttachmentConstructed[]>([]);
+  // Until the replica read settles, "no content" means "not known yet". Callers that would act on
+  // its absence — re-downloading a purchase, say — have to be able to tell the two apart.
+  const [isResolvingReplica, setIsResolvingReplica] = useState(true);
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   // Effects 1) and 2) below both read my own `/priv`, so they need the restored session.
   // `currentUserPubky` alone is persisted and rehydrates first, which would run them too early.
@@ -49,14 +52,21 @@ export function useUnlockedContent({ lock, lockFile, authorId }: UseUnlockedCont
     // My own post can't have a replicated copy (unlocking only happens on other people's posts).
     // Leans on the a == b policy: post author == lock creator. TODO:[Locks] #2283 — a != b breaks
     // that inference; decide by lock ownership (e.g. a local unlock index), not authorship.
-    if (authorId === currentUserPubky) return;
+    if (authorId === currentUserPubky) {
+      setIsResolvingReplica(false);
+      return;
+    }
 
     let cancelled = false;
+    setIsResolvingReplica(true);
     LocksController.fetchReplicatedContent({ lockUrl: lock, readerPubky: currentUserPubky })
       .then((result) => {
         if (!cancelled && result) applyContent(result);
       })
-      .catch(() => undefined); // already reported by the Err factory; fall back to the lock card
+      .catch(() => undefined) // already reported by the Err factory; fall back to the lock card
+      .finally(() => {
+        if (!cancelled) setIsResolvingReplica(false);
+      });
     return () => {
       cancelled = true;
     };
@@ -109,5 +119,5 @@ export function useUnlockedContent({ lock, lockFile, authorId }: UseUnlockedCont
     }
   };
 
-  return { unlockedPost, applyUnlockedContent, media, isOwnLock };
+  return { unlockedPost, applyUnlockedContent, media, isOwnLock, isResolvingReplica };
 }

--- a/src/hooks/useUnlockedContent/useUnlockedContent.types.ts
+++ b/src/hooks/useUnlockedContent/useUnlockedContent.types.ts
@@ -19,4 +19,6 @@ export interface UseUnlockedContentResult {
   media: AttachmentConstructed[];
   /** Whether the signed-in user is the lock's creator (owns the guarded storage). */
   isOwnLock: boolean;
+  /** The replica read has not settled, so an empty `unlockedPost` means "not known yet". */
+  isResolvingReplica: boolean;
 }

--- a/src/libs/utils/formatSats.test.ts
+++ b/src/libs/utils/formatSats.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { formatSats } from './formatSats';
+
+describe('formatSats', () => {
+  describe('amount formatting', () => {
+    it.each([
+      { amount: 0, expected: '₿0', case: 'zero' },
+      { amount: 1, expected: '₿1', case: 'one sat' },
+      { amount: 999, expected: '₿999', case: 'below the first grouping boundary' },
+      { amount: 1_000, expected: '₿1,000', case: 'at the first grouping boundary' },
+      { amount: 1_234_567_890, expected: '₿1,234,567,890', case: 'multiple groups' },
+      {
+        amount: Number.MAX_SAFE_INTEGER,
+        expected: '₿9,007,199,254,740,991',
+        case: 'the largest precisely representable integer',
+      },
+    ])('formats $case', ({ amount, expected }) => {
+      expect(formatSats(amount)).toBe(expected);
+    });
+
+    it.each([
+      ['0', '₿0'],
+      ['1000', '₿1,000'],
+      ['1234567890', '₿1,234,567,890'],
+      [String(Number.MAX_SAFE_INTEGER), '₿9,007,199,254,740,991'],
+    ])('formats numeric string %s', (amount, expected) => {
+      expect(formatSats(amount)).toBe(expected);
+    });
+  });
+
+  describe('symbol presentation', () => {
+    it('places the symbol directly before the amount by default', () => {
+      expect(formatSats(1_000)).toBe('₿1,000');
+    });
+
+    it('adds one space after the symbol when requested', () => {
+      expect(formatSats(1_000, { space: true })).toBe('₿ 1,000');
+    });
+
+    it('omits the symbol without changing the grouped amount', () => {
+      expect(formatSats(1_000, { symbol: false })).toBe('1,000');
+    });
+
+    it('ignores symbol spacing when the symbol is omitted', () => {
+      expect(formatSats(1_000, { symbol: false, space: true })).toBe('1,000');
+    });
+  });
+
+  describe('invalid amounts', () => {
+    it.each([
+      { amount: '', case: 'an empty string' },
+      { amount: ' ', case: 'whitespace' },
+      { amount: 'one thousand', case: 'non-numeric text' },
+      { amount: '1,000', case: 'a pre-formatted string' },
+      { amount: ' 1000', case: 'leading whitespace' },
+      { amount: '1000 ', case: 'trailing whitespace' },
+      { amount: '+1000', case: 'an explicit positive sign' },
+      { amount: '0001000', case: 'a non-canonical integer string' },
+      { amount: '1.5', case: 'a fractional string' },
+      { amount: '1e3', case: 'exponential notation' },
+      { amount: '-1', case: 'a negative string' },
+      { amount: -1, case: 'a negative number' },
+      { amount: 1.5, case: 'a fractional number' },
+      { amount: Number.NaN, case: 'NaN' },
+      { amount: Number.POSITIVE_INFINITY, case: 'positive infinity' },
+      { amount: Number.NEGATIVE_INFINITY, case: 'negative infinity' },
+      { amount: Number.MAX_SAFE_INTEGER + 1, case: 'an unsafe number' },
+      { amount: '9007199254740992', case: 'a numeric string above the safe range' },
+    ])('returns null for $case', ({ amount }) => {
+      expect(formatSats(amount)).toBeNull();
+    });
+
+    it('returns null before applying presentation options', () => {
+      expect(formatSats('invalid', { symbol: false, space: true })).toBeNull();
+    });
+  });
+});

--- a/src/libs/utils/formatSats.ts
+++ b/src/libs/utils/formatSats.ts
@@ -1,0 +1,29 @@
+const satsFormatter = new Intl.NumberFormat('en-US');
+const INTEGER_PATTERN = /^(0|[1-9]\d*)$/;
+const MAX_SAFE_SATS = BigInt(Number.MAX_SAFE_INTEGER);
+
+interface FormatSatsOptions {
+  symbol?: boolean;
+  space?: boolean;
+}
+
+/** Formats a non-negative, safe-integer satoshi amount; invalid amounts return null. */
+export function formatSats(
+  amount: number | string,
+  { symbol = true, space = false }: FormatSatsOptions = {},
+): string | null {
+  let sats: bigint;
+
+  if (typeof amount === 'number') {
+    if (!Number.isSafeInteger(amount) || amount < 0) return null;
+    sats = BigInt(amount);
+  } else {
+    if (!INTEGER_PATTERN.test(amount)) return null;
+    sats = BigInt(amount);
+    if (sats > MAX_SAFE_SATS) return null;
+  }
+
+  const formatted = satsFormatter.format(sats);
+  if (!symbol) return formatted;
+  return `₿${space ? ' ' : ''}${formatted}`;
+}


### PR DESCRIPTION
Closes #2368, closes #2297.


https://github.com/user-attachments/assets/0e8e35f7-c554-4e7a-a3eb-c6030ccf8095



A reader can now pay for a locked post with Bitkit and read it.

## What a reader can do

- Press Unlock on a paid lock and get the Pay to Unlock dialog instead of the password prompt
- Press Pay. The payment request arrives in their Bitkit wallet; the app never shows an address or an invoice
- Wait in the dialog while the payment goes through. It resumes on its own when the tab comes back from Bitkit, and offers Check again after three minutes
- See a confirmation with the amount paid, then press View Content to read the post
- Without a wallet, see the install steps for Bitkit instead of Pay

## What happens behind it

- A purchase is saved to the reader's own homeserver before the payment is sent, so it can always be found again. Reopening the dialog picks it up instead of paying twice
- A payment that failed or expired is replaced with a fresh one on the next Pay. A saved purchase that cannot be read blocks Pay rather than risk a second charge
- A payment that completed while the reader was away is finished in the background the next time the post is on screen

## Guardrails

- Nothing is sent by opening or closing the dialog. Only Pay sends a payment
- Closing during a payment asks first; the payment keeps running on the server either way
- Two tabs paying the same lock at the same moment can still create two payments (#2468)

## Testing

Needs the local Paykit stack (#2365) and the SDK built from pubky/locks#42.

Covered by tests:
- Purchase is saved before the payment is sent; a saved purchase is reused; a failed one is replaced; an unreadable one blocks Pay
- Opening never sends a payment; closing mid-payment asks first; a result arriving after close is ignored
- Polling stops on completed / failed / expired, parks after three minutes, and re-checks on tab focus
- Background recovery runs once per page load, only for paid posts with no replica, and not while the dialog is open
