### PR TITLE
perf(tags): stop re-fetching tags on every feed card mount

### DIFF
--- a/src/core/services/nexus/bootstrap/bootstrap.test.ts
+++ b/src/core/services/nexus/bootstrap/bootstrap.test.ts
@@ -163,9 +163,6 @@ describe('NexusBootstrapService', () => {
 
       expect(mockFetch).toHaveBeenCalledWith(bootstrapApi.get(pubky), {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
       });
       expect(result).toEqual(mockResponse);
     });

--- a/src/core/services/nexus/nexus.utils.test.ts
+++ b/src/core/services/nexus/nexus.utils.test.ts
@@ -50,18 +50,19 @@ describe('nexus.utils', () => {
   });
 
   describe('createFetchOptions', () => {
-    it('should create GET options with default headers', () => {
+    it('should create GET options without Content-Type (no CORS preflight)', () => {
       const result = createFetchOptions({ method: HttpMethod.GET });
       expect(result.method).toBe('GET');
-      expect(result.headers).toEqual({ 'Content-Type': 'application/json' });
+      expect(result.headers).toBeUndefined();
       expect(result.body).toBeUndefined();
     });
 
-    it('should create POST options with body', () => {
+    it('should create POST options with body and JSON headers', () => {
       const body = JSON.stringify({ key: 'value' });
       const result = createFetchOptions({ method: HttpMethod.POST, body });
       expect(result.method).toBe('POST');
       expect(result.body).toBe(body);
+      expect(result.headers).toEqual({ 'Content-Type': 'application/json' });
     });
   });
 

--- a/src/core/services/nexus/nexus.utils.ts
+++ b/src/core/services/nexus/nexus.utils.ts
@@ -56,14 +56,23 @@ export function buildUrlWithQuery({ baseRoute, params, excludeKeys = [] }: TBuil
 /**
  * Utility function to create fetch options with common headers.
  * Body must be a string (typically JSON.stringify'd) to ensure safe query key serialization.
+ *
+ * Content-Type is omitted on bodyless GETs: the header makes such requests
+ * non-"simple", forcing a CORS preflight OPTIONS round trip for every call.
+ * GETs have no body, so the header carries no information and only doubles
+ * the request count. All other requests (bodies, non-simple methods) keep it.
  */
 export function createFetchOptions({ method = HttpMethod.GET, body }: TCreateFetchOptionsParams = {}): RequestInit {
   const options: RequestInit = {
     method,
-    headers: JSON_HEADERS,
   };
 
-  if (body) options.body = body;
+  if (body) {
+    options.body = body;
+    options.headers = JSON_HEADERS;
+  } else if (method !== HttpMethod.GET) {
+    options.headers = JSON_HEADERS;
+  }
 
   return options;
 }

--- a/src/hooks/usePostTags/usePostTags.test.tsx
+++ b/src/hooks/usePostTags/usePostTags.test.tsx
@@ -95,17 +95,13 @@ describe('usePostTags', () => {
   });
 
   describe('initialization', () => {
-    it('should fetch initial tags from Nexus on mount', async () => {
+    it('should not fetch tags from Nexus on mount (local-first: render from IndexedDB)', async () => {
       renderHook(() => usePostTags('author:post123'));
 
-      await waitFor(() => {
-        expect(mockFetchTags).toHaveBeenCalledWith({
-          compositeId: 'author:post123',
-          skip: 0,
-          limit: TAGS_PER_PAGE,
-          viewerId: 'mock-user-id',
-        });
-      });
+      // Give any (removed) mount effect a chance to fire
+      await act(async () => {});
+
+      expect(mockFetchTags).not.toHaveBeenCalled();
     });
 
     it('should return loading state initially', () => {
@@ -538,16 +534,7 @@ describe('usePostTags', () => {
       // unique_tags > localTags.length so hasMore starts as true
       setupLiveQueryMock([{ tags: initialTags }], { unique_tags: 20 });
 
-      // Initial fetch on mount should return a full page so hasMore remains true.
-      mockFetchTags.mockResolvedValueOnce(
-        Array.from({ length: TAGS_PER_PAGE }, (_, i) => ({
-          label: `initial-tag-${i}`,
-          taggers_count: 1,
-          taggers: ['user-1'],
-        })),
-      );
-
-      // Then loadMore returns fewer than 10 tags (end of list)
+      // loadMore returns fewer than TAGS_PER_PAGE tags (end of list)
       mockFetchTags.mockResolvedValueOnce([
         { label: 'last-tag-1', taggers_count: 1, taggers: ['user-1'] },
         { label: 'last-tag-2', taggers_count: 1, taggers: ['user-1'] },
@@ -563,7 +550,7 @@ describe('usePostTags', () => {
 
       await result.current.loadMore();
 
-      // hasMore should now be false since we got < 10 tags
+      // hasMore should now be false since we got < TAGS_PER_PAGE tags
       await waitFor(() => {
         expect(result.current.hasMore).toBe(false);
       });

--- a/src/hooks/usePostTags/usePostTags.tsx
+++ b/src/hooks/usePostTags/usePostTags.tsx
@@ -13,11 +13,13 @@ import { TAGS_PER_PAGE } from './usePostTags.constants';
 import type { UsePostTagsOptions, UsePostTagsResult } from './usePostTags.types';
 
 /**
- * Hook for fetching and managing post tags with pagination.
+ * Hook for managing post tags with pagination.
  * Uses useLiveQuery with PostController for automatic reactivity.
  *
- * On mount, fetches the first page of tags from Nexus and merges into IndexedDB
- * so that tags from other users are visible (not just locally-created ones).
+ * Local-first: tags are read from IndexedDB (hydrated by stream fetches and the
+ * TTL coordinator's batch refresh, which both persist `post.tags`). No network
+ * fetch on mount — the first page of tags from Nexus is assumed to be in cache.
+ * Explicit "load more" pagination fetches from Nexus on demand.
  *
  * The TagController.commitCreate/commitDelete methods use local-first writes with
  * compensation rollback, so useLiveQuery reacts immediately and failed homeserver
@@ -35,7 +37,6 @@ export function usePostTags(postId: string | null | undefined, options: UsePostT
   const [paginationExhausted, setPaginationExhausted] = useState(false);
   const loadedCountRef = useRef(0);
   const prevPostIdRef = useRef<string | null | undefined>(null);
-  const [hasFetched, setHasFetched] = useState(false);
 
   // Track zero-tagger tags with their original index for order preservation
   const [zeroTaggerTags, setZeroTaggerTags] = useState<Map<string, { tag: NexusTag; index: number }>>(new Map());
@@ -57,7 +58,6 @@ export function usePostTags(postId: string | null | undefined, options: UsePostT
       setTagOrder(new Map());
       setRecentlyAddedLabels(new Map());
       addCounterRef.current = 0;
-      setHasFetched(false);
     }
   }, [postId]);
 
@@ -81,46 +81,6 @@ export function usePostTags(postId: string | null | undefined, options: UsePostT
     [postId],
     undefined,
   );
-
-  // Fetch first page of tags from Nexus on mount to ensure tags from other users are visible.
-  // PostApplication.fetchTags merges results into IndexedDB, so useLiveQuery reacts automatically.
-  useEffect(() => {
-    if (!postId || hasFetched) return;
-    let stale = false;
-
-    const fetchInitialTags = async () => {
-      try {
-        const fetchedTags = await PostController.fetchTags({
-          compositeId: postId,
-          skip: 0,
-          limit: TAGS_PER_PAGE,
-          viewerId: viewerId ?? undefined,
-        });
-
-        if (stale) return;
-        loadedCountRef.current = Math.max(loadedCountRef.current, fetchedTags.length);
-
-        if (fetchedTags.length < TAGS_PER_PAGE) {
-          setPaginationExhausted(true);
-        }
-      } catch {
-        // Silently fail — local tags (if any) are still shown via useLiveQuery
-      } finally {
-        if (!stale) setHasFetched(true);
-      }
-    };
-
-    fetchInitialTags();
-    return () => {
-      stale = true;
-    };
-    // `viewerId` is listed for parity with the user-tags hook (`useTagged`),
-    // but the `hasFetched` guard above means a mid-mount viewer change
-    // (e.g. user logs in on the same page) will not trigger a re-fetch.
-    // This matches existing behaviour and is out of scope for #1721.
-    // To support that case in the future, reset `hasFetched` when viewerId
-    // changes — see the `prevPostIdRef` pattern below for the shape.
-  }, [postId, hasFetched, viewerId]);
 
   const isLoading = tagsCollection === undefined;
 

--- a/src/hooks/useTagged/useTagged.test.tsx
+++ b/src/hooks/useTagged/useTagged.test.tsx
@@ -125,19 +125,13 @@ describe('useTagged', () => {
     expect(typeof result.current.loadMore).toBe('function');
   });
 
-  it('calls UserController.fetchTags with correct params', async () => {
+  it('does not fetch tags from Nexus on mount (local-first: render from IndexedDB)', async () => {
     renderHook(() => useTagged(mockUserId));
 
-    await waitFor(() => {
-      expect(mockMocks.mockFetchTags).toHaveBeenCalled();
-    });
+    // Give any (removed) mount effect a chance to fire
+    await act(async () => {});
 
-    expect(mockMocks.mockFetchTags).toHaveBeenCalledWith({
-      user_id: mockUserId,
-      viewer_id: 'mock-current-user',
-      limit_tags: 20,
-      skip_tags: 0,
-    });
+    expect(mockMocks.mockFetchTags).not.toHaveBeenCalled();
   });
 
   it('handleTagAdd returns error when tag label is empty', async () => {

--- a/src/hooks/useTagged/useTagged.tsx
+++ b/src/hooks/useTagged/useTagged.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { TagKind } from '@/application/tag/tag.types';
 import { TagController } from '@/controllers/tag/tag';
@@ -16,8 +16,13 @@ import { TAGS_PER_PAGE } from './useTagged.constants';
 import type { UseTaggedOptions, UseTaggedResult } from './useTagged.types';
 
 /**
- * Unified hook for fetching and managing user tags.
+ * Unified hook for managing user tags.
  * Uses useLiveQuery on IndexedDB for automatic reactivity across all instances.
+ *
+ * Local-first: user tags are read from IndexedDB (hydrated by user stream fetches,
+ * profile fetches and the TTL coordinator's batch refresh, which all persist
+ * `user.tags`). No network fetch on mount; explicit "load more" pagination
+ * fetches from Nexus on demand.
  *
  * The TagController.commitCreate/commitDelete methods use local-first writes with
  * compensation rollback, so useLiveQuery reacts immediately and failed homeserver
@@ -71,44 +76,6 @@ export function useTagged(userId: string | null | undefined, options: UseTaggedO
       return hasChanges ? newOrder : prevOrder;
     });
   }, [localTags]);
-
-  // Track if we've already fetched from server for this user
-  const [hasFetched, setHasFetched] = useState(false);
-  const prevUserIdRef = useRef<string | null | undefined>(null);
-
-  // Reset hasFetched when userId changes
-  useEffect(() => {
-    if (prevUserIdRef.current !== userId) {
-      setHasFetched(false);
-      prevUserIdRef.current = userId;
-    }
-  }, [userId]);
-
-  // Initial fetch from server (always fetch to ensure we have all tags)
-  useEffect(() => {
-    if (!userId || hasFetched) return;
-
-    const fetchTags = async () => {
-      try {
-        // Fetch from server
-        const fetchedTags = await UserController.fetchTags({
-          user_id: userId,
-          viewer_id: viewerId ?? undefined,
-          ...(enablePagination && { limit_tags: TAGS_PER_PAGE, skip_tags: 0 }),
-        });
-
-        // Save to IndexedDB so useLiveQuery reacts
-        await UserController.upsertTags(userId, fetchedTags);
-
-        setHasFetched(true);
-      } catch {
-        // Ignore fetch errors - we'll show empty state
-        setHasFetched(true);
-      }
-    };
-
-    fetchTags();
-  }, [userId, viewerId, enablePagination, hasFetched]);
 
   // Combine local tags with zero-tagger tags, preserving order
   const allTags = useMemo(() => {


### PR DESCRIPTION
Requested by @SHAcollision after navigating two already-loaded feeds kept firing `GET /v0/post/:id/tags?limit_tags=3` plus a CORS preflight OPTIONS per visible post card, so feed navigation no longer felt local-first.

**Cause.** `usePostTags` and `useTagged` fetch the first page of tags from Nexus on every mount. The behavior dates to the single-post view (#1474) and reached every feed row when the list layout added `ClickableTagsList` (#1951). The only guard is TanStack `staleTime` of 20s, so cycling feeds after 20s re-requests tags for every card. The data was already persisted by stream hydration (`persistPosts` saves `post.tags`) and is refreshed in batch by the TTL coordinator (`ttlPostMs` 5 min, by-ids response includes tags), making the per-card fetch a third redundant copy.

**Change.**
- `usePostTags` / `useTagged`: drop the fetch-on-mount effect; render from IndexedDB via `useLiveQuery`. Load-more pagination and local-first tag writes (commitCreate/commitDelete) are unchanged.
- `createFetchOptions`: omit `Content-Type` on bodyless GETs so they stay CORS-simple and stop triggering preflight OPTIONS. Bodies and non-simple methods keep the header.

**Verification.** `tsc --noEmit` clean; full unit suite at the pre-existing baseline on dev (95 snapshot/environment failures, unchanged; the only tests touched are the ones asserting the old fetch-on-mount and GET header contract). Affected suites green: hooks (usePostTags, useTagged, useEntityTags), nexus services, ClickableTagsList (same pre-existing snapshot diffs as dev).

Net effect on revisiting a loaded feed: 0 tag GETs, 0 preflight OPTIONS, tags render synchronously from cache. Ephemeral preview link should show instant feed switching with no per-card skeleton.