### PR TITLE
fix(ui): hide mobile chrome while typing and scrolling down

### DIFF
--- a/src/components/molecules/Fab/Fab.test.tsx
+++ b/src/components/molecules/Fab/Fab.test.tsx
@@ -16,6 +16,7 @@ const mockIsPublicExploreRoute = vi.fn(() => false);
 const mockRequireAuth = vi.fn((action: () => void) => action());
 const mockUseFabAction = vi.fn<() => FabAction>(() => ({ kind: 'createPost', ariaLabel: 'New post' }));
 const mockUsePathname = vi.fn(() => '/home');
+const mockUseKeyboardOffset = vi.fn(() => ({ isKeyboardVisible: false, keyboardOffset: 0 }));
 
 vi.mock('next/navigation', () => ({
   usePathname: () => mockUsePathname(),
@@ -43,6 +44,10 @@ vi.mock('@/hooks/useRequireAuth/useRequireAuth', () => ({
 
 vi.mock('@/hooks/useFabAction/useFabAction', () => ({
   useFabAction: () => mockUseFabAction(),
+}));
+
+vi.mock('@/hooks/useKeyboardOffset/useKeyboardOffset', () => ({
+  useKeyboardOffset: () => mockUseKeyboardOffset(),
 }));
 
 vi.mock('@/organisms/DialogNewPost/DialogNewPost', () => ({
@@ -115,6 +120,7 @@ describe('Fab', () => {
     mockRequireAuth.mockImplementation((action: () => void) => action());
     mockUseFabAction.mockReturnValue({ kind: 'createPost', ariaLabel: 'New post' });
     mockUsePathname.mockReturnValue('/home');
+    mockUseKeyboardOffset.mockReturnValue({ isKeyboardVisible: false, keyboardOffset: 0 });
     useCollectionReorderStore.setState({ activeCollectionId: null });
   });
 
@@ -248,6 +254,18 @@ describe('Fab', () => {
       expect(mockRequireAuth).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('while the soft keyboard is visible', () => {
+    it('renders nothing so the button does not cover the text being typed', () => {
+      mockUseKeyboardOffset.mockReturnValue({ isKeyboardVisible: true, keyboardOffset: 300 });
+
+      const { container } = render(<Fab />);
+
+      expect(container).toBeEmptyDOMElement();
+      expect(screen.queryByTestId('new-post-cta')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('dialog-new-post')).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe('Fab - Snapshots', () => {
@@ -263,6 +281,7 @@ describe('Fab - Snapshots', () => {
     mockIsPublicExploreRoute.mockReturnValue(false);
     mockRequireAuth.mockImplementation((action: () => void) => action());
     mockUseFabAction.mockReturnValue({ kind: 'createPost', ariaLabel: 'New post' });
+    mockUseKeyboardOffset.mockReturnValue({ isKeyboardVisible: false, keyboardOffset: 0 });
   });
 
   it('matches snapshot for the default new post action', () => {

--- a/src/components/molecules/Fab/Fab.test.tsx
+++ b/src/components/molecules/Fab/Fab.test.tsx
@@ -132,16 +132,16 @@ describe('Fab', () => {
     expect(button).toHaveAttribute('aria-label', 'New post');
   });
 
-  it('returns null while a collection is in reorder mode', () => {
+  it('hides the button while a collection is in reorder mode', () => {
     useCollectionReorderStore.setState({ activeCollectionId: 'author:collection123' });
-    const { container } = render(<Fab />);
-    expect(container.firstChild).toBeNull();
+    render(<Fab />);
+    expect(screen.queryByTestId('new-post-cta')).not.toBeInTheDocument();
   });
 
   it('reappears when reorder mode exits', () => {
     useCollectionReorderStore.setState({ activeCollectionId: 'author:collection123' });
-    const { container } = render(<Fab />);
-    expect(container.firstChild).toBeNull();
+    render(<Fab />);
+    expect(screen.queryByTestId('new-post-cta')).not.toBeInTheDocument();
 
     act(() => useCollectionReorderStore.getState().exit());
 
@@ -172,10 +172,10 @@ describe('Fab', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('returns null on onboarding routes even when fully authenticated', () => {
+  it('hides the button on onboarding routes even when fully authenticated', () => {
     mockUsePathname.mockReturnValue('/onboarding/tags');
-    const { container } = render(<Fab />);
-    expect(container.firstChild).toBeNull();
+    render(<Fab />);
+    expect(screen.queryByTestId('new-post-cta')).not.toBeInTheDocument();
   });
 
   describe('createPost action', () => {
@@ -256,14 +256,21 @@ describe('Fab', () => {
   });
 
   describe('while the soft keyboard is visible', () => {
-    it('renders nothing so the button does not cover the text being typed', () => {
+    it('hides the button so it does not cover the text being typed, but keeps the dialog mounted', () => {
       mockUseKeyboardOffset.mockReturnValue({ isKeyboardVisible: true, keyboardOffset: 300 });
 
-      const { container } = render(<Fab />);
+      render(<Fab />);
 
-      expect(container).toBeEmptyDOMElement();
       expect(screen.queryByTestId('new-post-cta')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('dialog-new-post')).not.toBeInTheDocument();
+      // The dialog must survive: unmounting it with the button killed the open
+      // composer when its textarea raised the keyboard (focus loop, PR 2489 QA).
+      expect(screen.getByTestId('dialog-new-post')).toBeInTheDocument();
+    });
+
+    it('shows the button again once the keyboard closes', () => {
+      mockUseKeyboardOffset.mockReturnValue({ isKeyboardVisible: false, keyboardOffset: 0 });
+      render(<Fab />);
+      expect(screen.getByTestId('new-post-cta')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/molecules/Fab/Fab.tsx
+++ b/src/components/molecules/Fab/Fab.tsx
@@ -6,6 +6,7 @@ import { Plus } from 'lucide-react';
 import { Button } from '@/atoms/Button/Button';
 import { useAuthStatus } from '@/hooks/useAuthStatus/useAuthStatus';
 import { useFabAction } from '@/hooks/useFabAction/useFabAction';
+import { useKeyboardOffset } from '@/hooks/useKeyboardOffset/useKeyboardOffset';
 import { usePublicRoute } from '@/hooks/usePublicRoute/usePublicRoute';
 import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
 import { cn } from '@/libs/utils/utils';
@@ -34,6 +35,8 @@ import { useCollectionReorderStore } from '@/stores/collectionReorder/collection
  * - Hidden while a collection is in reorder mode (reorder mode is for
  *   reordering, not adding posts; the flag bridges from the page via the
  *   `collectionReorder` store since the FAB lives outside the page tree)
+ * - Hidden while the soft keyboard is visible on mobile: the button sits at
+ *   the bottom of the screen and covers the text being typed
  *
  * Positioning:
  * - On small screens (sm), the button sits directly on top of the menu bar by design.
@@ -47,12 +50,13 @@ export function Fab() {
   const { isPublicExploreRoute } = usePublicRoute();
   const { requireAuth } = useRequireAuth();
   const action = useFabAction();
+  const { isKeyboardVisible } = useKeyboardOffset();
   const isReorderActive = useCollectionReorderStore((state) => state.activeCollectionId !== null);
 
   const isOnboardingRoute = pathname?.startsWith('/onboarding') ?? false;
   // Show FAB for authenticated users OR unauthenticated users on public explore routes
   const shouldShow = isFullyAuthenticated || isPublicExploreRoute;
-  if (isLoading || !shouldShow || isReorderActive || isOnboardingRoute) {
+  if (isLoading || !shouldShow || isReorderActive || isOnboardingRoute || isKeyboardVisible) {
     return null;
   }
   const buttonClasses = cn(

--- a/src/components/molecules/Fab/Fab.tsx
+++ b/src/components/molecules/Fab/Fab.tsx
@@ -56,9 +56,11 @@ export function Fab() {
   const isOnboardingRoute = pathname?.startsWith('/onboarding') ?? false;
   // Show FAB for authenticated users OR unauthenticated users on public explore routes
   const shouldShow = isFullyAuthenticated || isPublicExploreRoute;
-  if (isLoading || !shouldShow || isReorderActive || isOnboardingRoute || isKeyboardVisible) {
-    return null;
-  }
+  // Hide only the button while the keyboard is open. The context dialogs stay
+  // mounted: they are this component's children, so unmounting the whole Fab
+  // (the old behavior) killed the open New Post dialog the moment its textarea
+  // raised the keyboard, dropped focus and closed the keyboard in a loop.
+  const showButton = !isLoading && shouldShow && !isReorderActive && !isOnboardingRoute && !isKeyboardVisible;
   const buttonClasses = cn(
     'fixed right-3 bottom-18 sm:right-10 md:bottom-20 lg:bottom-6',
     'size-20 rounded-full',
@@ -70,7 +72,7 @@ export function Fab() {
     'group cursor-pointer',
     'z-40',
   );
-  const button = (
+  const button = showButton ? (
     <Button
       data-cy="new-post-btn"
       overrideDefaults
@@ -81,14 +83,16 @@ export function Fab() {
     >
       <Plus className="size-10 transition-colors group-hover:text-black" strokeWidth={0.8} />
     </Button>
-  );
+  ) : null;
 
   // Unauthenticated: button only opens the sign-in dialog via requireAuth
   if (!isFullyAuthenticated) {
     return button;
   }
 
-  // Authenticated: render the button next to the context dialog it controls
+  // Authenticated: render the button next to the context dialog it controls.
+  // The dialog renders even while the button is hidden (keyboard open), so an
+  // open composer survives the keyboard lifecycle.
   return (
     <>
       {button}

--- a/src/components/molecules/MobileFooter/MobileFooter.test.tsx
+++ b/src/components/molecules/MobileFooter/MobileFooter.test.tsx
@@ -446,17 +446,15 @@ describe('MobileFooter', () => {
     expect(setItemSpy).toHaveBeenCalledWith(FORCE_FEED_SCROLL_TOP_KEY, '1');
   });
 
-  it('applies transform when keyboard is visible', async () => {
+  it('renders nothing while the keyboard is visible', async () => {
     vi.mocked(useKeyboardOffset).mockReturnValue({ isKeyboardVisible: true, keyboardOffset: 300 });
 
     const { container } = render(<MobileFooter />);
-    const footerContainer = container.querySelector('.fixed');
 
-    expect(footerContainer).toBeInTheDocument();
-    expect(footerContainer?.getAttribute('style')).toContain('translateY(-300px)');
+    expect(container).toBeEmptyDOMElement();
   });
 
-  it('does not apply transform when keyboard is not visible', async () => {
+  it('renders normally when the keyboard is not visible', async () => {
     vi.mocked(useKeyboardOffset).mockReturnValue({ isKeyboardVisible: false, keyboardOffset: 0 });
 
     const { container } = render(<MobileFooter />);
@@ -466,18 +464,14 @@ describe('MobileFooter', () => {
     expect(footerContainer?.getAttribute('style')).toBeFalsy();
   });
 
-  it('always applies transition classes for smooth keyboard animation', async () => {
-    // transition-transform and duration-75 are always present regardless of keyboard state
+  it('always renders the footer container without keyboard transform classes', async () => {
+    // The footer unmounts entirely while the keyboard is open (#2286), so no
+    // transition classes are needed for the keyboard state anymore
     vi.mocked(useKeyboardOffset).mockReturnValue({ isKeyboardVisible: false, keyboardOffset: 0 });
-    const { container, rerender } = render(<MobileFooter />);
-    let footerContainer = container.querySelector('.fixed');
-    expect(footerContainer).toHaveClass('transition-transform', 'duration-75');
-
-    // Still present when keyboard is visible
-    vi.mocked(useKeyboardOffset).mockReturnValue({ isKeyboardVisible: true, keyboardOffset: 300 });
-    rerender(<MobileFooter />);
-    footerContainer = container.querySelector('.fixed');
-    expect(footerContainer).toHaveClass('transition-transform', 'duration-75');
+    const { container } = render(<MobileFooter />);
+    const footerContainer = container.querySelector('.fixed');
+    expect(footerContainer).toBeInTheDocument();
+    expect(footerContainer).not.toHaveClass('transition-transform');
   });
 
   it('renders public explore navigation with gated account actions when unauthenticated on a core explore route', () => {

--- a/src/components/molecules/MobileFooter/MobileFooter.test.tsx.snap
+++ b/src/components/molecules/MobileFooter/MobileFooter.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`MobileFooter - Snapshots > matches snapshot for profile link 1`] = `
 
 exports[`MobileFooter - Snapshots > matches snapshot with custom className 1`] = `
 <div
-  class="fixed bottom-0 z-40 w-full overflow-x-auto bg-gradient-to-t from-background via-background/95 to-transparent px-3 py-4 transition-transform duration-75 lg:hidden custom-footer"
+  class="fixed bottom-0 z-40 w-full overflow-x-auto bg-gradient-to-t from-background via-background/95 to-transparent px-3 py-4 lg:hidden custom-footer"
   data-testid="container"
 >
   <div
@@ -230,7 +230,7 @@ exports[`MobileFooter - Snapshots > matches snapshot with custom className 1`] =
 
 exports[`MobileFooter - Snapshots > matches snapshot with default props 1`] = `
 <div
-  class="fixed bottom-0 z-40 w-full overflow-x-auto bg-gradient-to-t from-background via-background/95 to-transparent px-3 py-4 transition-transform duration-75 lg:hidden"
+  class="fixed bottom-0 z-40 w-full overflow-x-auto bg-gradient-to-t from-background via-background/95 to-transparent px-3 py-4 lg:hidden"
   data-testid="container"
 >
   <div
@@ -403,7 +403,7 @@ exports[`MobileFooter - Snapshots > matches snapshot with default props 1`] = `
 
 exports[`MobileFooter - Snapshots > matches snapshot with different active path 1`] = `
 <div
-  class="fixed bottom-0 z-40 w-full overflow-x-auto bg-gradient-to-t from-background via-background/95 to-transparent px-3 py-4 transition-transform duration-75 lg:hidden"
+  class="fixed bottom-0 z-40 w-full overflow-x-auto bg-gradient-to-t from-background via-background/95 to-transparent px-3 py-4 lg:hidden"
   data-testid="container"
 >
   <div

--- a/src/components/molecules/MobileFooter/MobileFooter.tsx
+++ b/src/components/molecules/MobileFooter/MobileFooter.tsx
@@ -29,6 +29,10 @@ export interface MobileFooterProps {
  *
  * Hidden for unauthenticated users on public routes (single post, profile)
  * following pubky-app pattern.
+ *
+ * Hidden while the soft keyboard is visible (design decision in #2286):
+ * the keyboard owns the bottom of the screen and the nav would otherwise
+ * cover the text field.
  */
 export function MobileFooter({ className }: MobileFooterProps) {
   const pathname = usePathname();
@@ -38,7 +42,7 @@ export function MobileFooter({ className }: MobileFooterProps) {
   const { userDetails, currentUserPubky } = useCurrentUserProfile();
   const unreadNotifications = useNotificationStore((state) => state.selectUnread());
   const localAvatarUrl = useLocalFilesStore((state) => state.profile);
-  const { isKeyboardVisible, keyboardOffset } = useKeyboardOffset();
+  const { isKeyboardVisible } = useKeyboardOffset();
   const { showCollectionsNew, markCollectionsNavSeen } = useCollectionsNavDiscovery();
   const collectionsNewLabel = 'New';
 
@@ -49,6 +53,14 @@ export function MobileFooter({ className }: MobileFooterProps) {
       ? FileController.getAvatarUrl(currentUserPubky, userDetails.indexed_at)
       : undefined);
   const avatarName = userDetails?.name || 'U';
+
+  // Hide the whole nav while the keyboard is open instead of translating it
+  // out of the way: the keyboard owns the bottom of the screen and the nav
+  // would otherwise sit on top of the composer text (see issue #2286).
+  if (isKeyboardVisible) {
+    return null;
+  }
+
   const authenticatedNavItems = [
     {
       href: APP_ROUTES.HOME,
@@ -91,16 +103,9 @@ export function MobileFooter({ className }: MobileFooterProps) {
     <Container
       overrideDefaults
       className={cn(
-        'fixed bottom-0 z-40 w-full overflow-x-auto bg-gradient-to-t from-background via-background/95 to-transparent px-3 py-4 transition-transform duration-75 lg:hidden',
+        'fixed bottom-0 z-40 w-full overflow-x-auto bg-gradient-to-t from-background via-background/95 to-transparent px-3 py-4 lg:hidden',
         className,
       )}
-      style={
-        isKeyboardVisible && keyboardOffset > 0
-          ? {
-              transform: `translateY(-${keyboardOffset}px)`,
-            }
-          : undefined
-      }
     >
       <Container
         overrideDefaults

--- a/src/components/molecules/MobileHeader/MobileHeader.test.tsx
+++ b/src/components/molecules/MobileHeader/MobileHeader.test.tsx
@@ -38,12 +38,24 @@ vi.mock('@/hooks/usePublicRoute/usePublicRoute', () => ({
   })),
 }));
 
+const mockUseKeyboardOffset = vi.hoisted(() => vi.fn(() => ({ isKeyboardVisible: false, keyboardOffset: 0 })));
+vi.mock('@/hooks/useKeyboardOffset/useKeyboardOffset', () => ({
+  useKeyboardOffset: mockUseKeyboardOffset,
+}));
+
+const mockUseScrollDirection = vi.hoisted(() => vi.fn<() => 'up' | 'down' | null>(() => null));
+vi.mock('@/hooks/useScrollDirection/useScrollDirection', () => ({
+  useScrollDirection: mockUseScrollDirection,
+}));
+
 describe('MobileHeader', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCurrentUserPubky = 'pk:test-user-pubky';
     mockIsCoreExploreRoute = false;
     mockIsPublicExploreRoute = false;
+    mockUseKeyboardOffset.mockReturnValue({ isKeyboardVisible: false, keyboardOffset: 0 });
+    mockUseScrollDirection.mockReturnValue(null);
   });
 
   it('renders with default props', () => {
@@ -223,6 +235,38 @@ describe('MobileHeader', () => {
 
     expect(mockSetShowSignInDialog).toHaveBeenCalledWith(true);
   });
+
+  it('renders nothing while the soft keyboard is visible', () => {
+    mockUseKeyboardOffset.mockReturnValue({ isKeyboardVisible: true, keyboardOffset: 300 });
+
+    const { container } = render(<MobileHeader />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing while the user scrolls down', () => {
+    mockUseScrollDirection.mockReturnValue('down');
+
+    const { container } = render(<MobileHeader />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders again when the user scrolls back up', () => {
+    mockUseScrollDirection.mockReturnValue('up');
+
+    const { container } = render(<MobileHeader />);
+
+    expect(container.querySelector('div')).toBeInTheDocument();
+  });
+
+  it('renders when scroll direction is null (not yet scrolled)', () => {
+    mockUseScrollDirection.mockReturnValue(null);
+
+    const { container } = render(<MobileHeader />);
+
+    expect(container.querySelector('div')).toBeInTheDocument();
+  });
 });
 
 describe('MobileHeader - Snapshots', () => {
@@ -231,6 +275,8 @@ describe('MobileHeader - Snapshots', () => {
     mockCurrentUserPubky = 'pk:test-user-pubky';
     mockIsCoreExploreRoute = false;
     mockIsPublicExploreRoute = false;
+    mockUseKeyboardOffset.mockReturnValue({ isKeyboardVisible: false, keyboardOffset: 0 });
+    mockUseScrollDirection.mockReturnValue(null);
   });
 
   it('matches snapshot with default props', () => {

--- a/src/components/molecules/MobileHeader/MobileHeader.tsx
+++ b/src/components/molecules/MobileHeader/MobileHeader.tsx
@@ -4,7 +4,9 @@ import type React from 'react';
 import { Button } from '@/atoms/Button/Button';
 import { Container } from '@/atoms/Container/Container';
 import { CONTENT_GUTTER_CLASS } from '@/config/layoutClasses';
+import { useKeyboardOffset } from '@/hooks/useKeyboardOffset/useKeyboardOffset';
 import { usePublicRoute } from '@/hooks/usePublicRoute/usePublicRoute';
+import { useScrollDirection } from '@/hooks/useScrollDirection/useScrollDirection';
 import { cn } from '@/libs/utils/utils';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import { Logo } from '../Logo/Logo';
@@ -36,9 +38,19 @@ export function MobileHeader({
   const isAuthenticated = useAuthStore((state) => Boolean(state.currentUserPubky));
   const setShowSignInDialog = useAuthStore((state) => state.setShowSignInDialog);
   const { isPublicExploreRoute } = usePublicRoute();
+  const { isKeyboardVisible } = useKeyboardOffset();
+  const scrollDirection = useScrollDirection();
+  // Hide while the user scrolls down to give the content the full screen, or
+  // while the soft keyboard is open. Return with an upward scroll.
+  const isHidden = isKeyboardVisible || scrollDirection === 'down';
   // Layout filters drawer: signed-in users and guests on explore/public routes (/home, /post/..., etc.)
   const showLeftIcon = showLeftButton && (isAuthenticated || isPublicExploreRoute);
   const rightButtonLabel = isAuthenticated ? 'Open right panel' : 'Join Pubky';
+
+  if (isHidden) {
+    return null;
+  }
+
   return (
     <Container
       overrideDefaults

--- a/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx
@@ -20,6 +20,12 @@ vi.mock('@/hooks/useKeyboardOffset/useKeyboardOffset', () => ({
   })),
 }));
 
+// Scroll direction moves the strip's sticky offset when the header hides; controllable per test
+let mockScrollDirection: 'up' | 'down' | null = null;
+vi.mock('@/hooks/useScrollDirection/useScrollDirection', () => ({
+  useScrollDirection: vi.fn(() => mockScrollDirection),
+}));
+
 // Mock dexie-react-hooks — allow controlling useLiveQuery return value per test
 let mockCustomFeeds: FeedModelSchema[];
 let mockIsAuthenticated = true;
@@ -223,6 +229,7 @@ describe('FeedNavigation', () => {
     mockHomeState.taggedAsActive = false;
     mockHomeState.profileTags = [];
     mockIsKeyboardVisible = false;
+    mockScrollDirection = null;
     mockRequireAuth.mockImplementation((action: () => unknown) => action());
     mockUsePathname.mockReturnValue('/home');
     mockGetList.mockResolvedValue([]);
@@ -647,22 +654,40 @@ describe('FeedNavigation', () => {
     expect(row).toHaveClass('overflow-x-auto');
   });
 
-  it('unmounts while the soft keyboard is open so it stops covering the composer', () => {
+  it('hides via CSS while the soft keyboard is open so it stops covering the composer', () => {
     mockIsKeyboardVisible = true;
     render(<FeedNavigation />);
 
-    expect(screen.queryByText('All')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('custom-feed-dialog-create')).not.toBeInTheDocument();
+    // Stays mounted (it hosts the custom-feed dialogs) but visually hidden.
+    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getAllByTestId('container')[0]).toHaveClass('invisible');
   });
 
-  it('returns when the keyboard closes', () => {
+  it('returns visible when the keyboard closes', () => {
     mockIsKeyboardVisible = true;
     const { rerender } = render(<FeedNavigation />);
-    expect(screen.queryByText('All')).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('container')[0]).toHaveClass('invisible');
 
     mockIsKeyboardVisible = false;
     rerender(<FeedNavigation />);
-    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getAllByTestId('container')[0]).not.toHaveClass('invisible');
+    expect(screen.getByText('All')).toBeVisible();
+  });
+
+  it('sticks under the mobile header by default, at the viewport top while the header is scrolled away', () => {
+    const { rerender } = render(<FeedNavigation />);
+    expect(screen.getAllByTestId('container')[0]).toHaveClass('top-(--header-height-settings)');
+    expect(screen.getAllByTestId('container')[0]).not.toHaveClass('top-0');
+
+    // Header hides on downward scroll: the strip must slide up with it, or an
+    // empty 72px band stays above it (the "strange gap").
+    mockScrollDirection = 'down';
+    rerender(<FeedNavigation />);
+    expect(screen.getAllByTestId('container')[0]).toHaveClass('top-0');
+
+    mockScrollDirection = 'up';
+    rerender(<FeedNavigation />);
+    expect(screen.getAllByTestId('container')[0]).toHaveClass('top-(--header-height-settings)');
   });
 
   it('renders tabs with Figma chrome classes', () => {

--- a/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx
@@ -11,6 +11,15 @@ vi.mock('next/navigation', () => ({
   usePathname: () => mockUsePathname(),
 }));
 
+// Keyboard state drives the mobile chrome hiding (see #2286); controllable per test
+let mockIsKeyboardVisible = false;
+vi.mock('@/hooks/useKeyboardOffset/useKeyboardOffset', () => ({
+  useKeyboardOffset: vi.fn(() => ({
+    isKeyboardVisible: mockIsKeyboardVisible,
+    keyboardOffset: mockIsKeyboardVisible ? 300 : 0,
+  })),
+}));
+
 // Mock dexie-react-hooks — allow controlling useLiveQuery return value per test
 let mockCustomFeeds: FeedModelSchema[];
 let mockIsAuthenticated = true;
@@ -213,6 +222,7 @@ describe('FeedNavigation', () => {
     mockHomeState.reach = REACH.ALL;
     mockHomeState.taggedAsActive = false;
     mockHomeState.profileTags = [];
+    mockIsKeyboardVisible = false;
     mockRequireAuth.mockImplementation((action: () => unknown) => action());
     mockUsePathname.mockReturnValue('/home');
     mockGetList.mockResolvedValue([]);
@@ -635,6 +645,24 @@ describe('FeedNavigation', () => {
     expect(wrapper).not.toHaveClass('overflow-x-auto');
     expect(row).toHaveClass('flex', 'flex-row');
     expect(row).toHaveClass('overflow-x-auto');
+  });
+
+  it('unmounts while the soft keyboard is open so it stops covering the composer', () => {
+    mockIsKeyboardVisible = true;
+    render(<FeedNavigation />);
+
+    expect(screen.queryByText('All')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('custom-feed-dialog-create')).not.toBeInTheDocument();
+  });
+
+  it('returns when the keyboard closes', () => {
+    mockIsKeyboardVisible = true;
+    const { rerender } = render(<FeedNavigation />);
+    expect(screen.queryByText('All')).not.toBeInTheDocument();
+
+    mockIsKeyboardVisible = false;
+    rerender(<FeedNavigation />);
+    expect(screen.getByText('All')).toBeInTheDocument();
   });
 
   it('renders tabs with Figma chrome classes', () => {

--- a/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx.snap
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`FeedNavigation - Snapshots > matches snapshot with custom feed active (showing edit dialog) 1`] = `
 <div
-  class="-mx-4 lg:mx-0 w-auto lg:w-full mobile-menu-gradient-fade sticky top-(--header-height-settings) z-(--z-mobile-menu) bg-background lg:static lg:top-auto lg:z-auto lg:bg-transparent lg:after:hidden"
+  class="-mx-4 lg:mx-0 w-auto lg:w-full mobile-menu-gradient-fade sticky z-(--z-mobile-menu) bg-background top-(--header-height-settings) lg:static lg:top-auto lg:z-auto lg:bg-transparent lg:after:hidden"
   data-testid="container"
 >
   <div
@@ -169,7 +169,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feed active (
 
 exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Home active 1`] = `
 <div
-  class="-mx-4 lg:mx-0 w-auto lg:w-full mobile-menu-gradient-fade sticky top-(--header-height-settings) z-(--z-mobile-menu) bg-background lg:static lg:top-auto lg:z-auto lg:bg-transparent lg:after:hidden"
+  class="-mx-4 lg:mx-0 w-auto lg:w-full mobile-menu-gradient-fade sticky z-(--z-mobile-menu) bg-background top-(--header-height-settings) lg:static lg:top-auto lg:z-auto lg:bg-transparent lg:after:hidden"
   data-testid="container"
 >
   <div
@@ -400,7 +400,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Hom
 
 exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feeds and one active 1`] = `
 <div
-  class="-mx-4 lg:mx-0 w-auto lg:w-full mobile-menu-gradient-fade sticky top-(--header-height-settings) z-(--z-mobile-menu) bg-background lg:static lg:top-auto lg:z-auto lg:bg-transparent lg:after:hidden"
+  class="-mx-4 lg:mx-0 w-auto lg:w-full mobile-menu-gradient-fade sticky z-(--z-mobile-menu) bg-background top-(--header-height-settings) lg:static lg:top-auto lg:z-auto lg:bg-transparent lg:after:hidden"
   data-testid="container"
 >
   <div
@@ -695,7 +695,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
 
 exports[`FeedNavigation - Snapshots > matches snapshot with no custom feeds and Home active 1`] = `
 <div
-  class="-mx-4 lg:mx-0 w-auto lg:w-full mobile-menu-gradient-fade sticky top-(--header-height-settings) z-(--z-mobile-menu) bg-background lg:static lg:top-auto lg:z-auto lg:bg-transparent lg:after:hidden"
+  class="-mx-4 lg:mx-0 w-auto lg:w-full mobile-menu-gradient-fade sticky z-(--z-mobile-menu) bg-background top-(--header-height-settings) lg:static lg:top-auto lg:z-auto lg:bg-transparent lg:after:hidden"
   data-testid="container"
 >
   <div

--- a/src/components/organisms/FeedNavigation/FeedNavigation.tsx
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.tsx
@@ -12,6 +12,7 @@ import { Link } from '@/atoms/Link/Link';
 import { Typography } from '@/atoms/Typography/Typography';
 import { FULL_BLEED_GUTTER_CLASS } from '@/config/layoutClasses';
 import { FeedController } from '@/controllers/feed/feed';
+import { useKeyboardOffset } from '@/hooks/useKeyboardOffset/useKeyboardOffset';
 import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
 import { useSelectedReachFilter } from '@/hooks/useSelectedReachFilter/useSelectedReachFilter';
 import { Logger } from '@/libs/logger/logger';
@@ -59,6 +60,11 @@ interface FeedNavigationProps {
 export const FeedNavigation = ({ className }: FeedNavigationProps) => {
   const pathname = usePathname();
   const { isAuthenticated, requireAuth } = useRequireAuth();
+  // Below lg this strip is sticky chrome under the mobile header. Hide it while
+  // the soft keyboard is open, like MobileHeader/MobileFooter/Fab do (#2286):
+  // otherwise tapping the inline composer on Home / My network leaves the tab
+  // bar pinned over the text.
+  const { isKeyboardVisible } = useKeyboardOffset();
   const [editingFeed, setEditingFeed] = useState<FeedModelSchema | null>(null);
   const customFeeds = useLiveQuery(
     async () => {
@@ -117,6 +123,12 @@ export const FeedNavigation = ({ className }: FeedNavigationProps) => {
     FEED_TAB_INACTIVE_PADDING_CLASS,
     'cursor-pointer border-border text-muted-foreground hover:text-white',
   );
+
+  const isHidden = isKeyboardVisible;
+
+  if (isHidden) {
+    return null;
+  }
 
   return (
     <Container

--- a/src/components/organisms/FeedNavigation/FeedNavigation.tsx
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.tsx
@@ -14,6 +14,7 @@ import { FULL_BLEED_GUTTER_CLASS } from '@/config/layoutClasses';
 import { FeedController } from '@/controllers/feed/feed';
 import { useKeyboardOffset } from '@/hooks/useKeyboardOffset/useKeyboardOffset';
 import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
+import { useScrollDirection } from '@/hooks/useScrollDirection/useScrollDirection';
 import { useSelectedReachFilter } from '@/hooks/useSelectedReachFilter/useSelectedReachFilter';
 import { Logger } from '@/libs/logger/logger';
 import { preloadLucideIcons } from '@/libs/lucide/lucideIcons';
@@ -63,8 +64,15 @@ export const FeedNavigation = ({ className }: FeedNavigationProps) => {
   // Below lg this strip is sticky chrome under the mobile header. Hide it while
   // the soft keyboard is open, like MobileHeader/MobileFooter/Fab do (#2286):
   // otherwise tapping the inline composer on Home / My network leaves the tab
-  // bar pinned over the text.
+  // bar pinned over the text. This component also hosts the custom-feed
+  // create/edit dialogs, so it must never unmount while the keyboard is open.
   const { isKeyboardVisible } = useKeyboardOffset();
+  // Track the same scroll signal MobileHeader uses: when the header hides on a
+  // downward scroll, nothing fills its 72px slot, so the strip sticks at
+  // `top-(--header-height-settings)` over an empty band ("strange gap to the
+  // top"). Move the sticky offset to the viewport top in that state.
+  const scrollDirection = useScrollDirection();
+  const isHeaderScrolledAway = scrollDirection === 'down';
   const [editingFeed, setEditingFeed] = useState<FeedModelSchema | null>(null);
   const customFeeds = useLiveQuery(
     async () => {
@@ -124,12 +132,6 @@ export const FeedNavigation = ({ className }: FeedNavigationProps) => {
     'cursor-pointer border-border text-muted-foreground hover:text-white',
   );
 
-  const isHidden = isKeyboardVisible;
-
-  if (isHidden) {
-    return null;
-  }
-
   return (
     <Container
       className={cn(
@@ -141,7 +143,12 @@ export const FeedNavigation = ({ className }: FeedNavigationProps) => {
         // The sticky chrome and gradient fade live on this non-scrolling
         // wrapper — on the scroll container itself the ::after fade would be
         // clipped into the scrollport and add phantom vertical scroll.
-        'mobile-menu-gradient-fade sticky top-(--header-height-settings) z-(--z-mobile-menu) bg-background',
+        'mobile-menu-gradient-fade sticky z-(--z-mobile-menu) bg-background',
+        // Stick under the mobile header by default; slide to the viewport top
+        // while the header is hidden by a downward scroll, so no empty band is
+        // left above the strip. Keyboard-open fully hides the strip below.
+        isHeaderScrolledAway ? 'top-0' : 'top-(--header-height-settings)',
+        isKeyboardVisible && 'invisible',
         'lg:static lg:top-auto lg:z-auto lg:bg-transparent lg:after:hidden',
         className,
       )}

--- a/src/hooks/useScrollDirection/useScrollDirection.test.ts
+++ b/src/hooks/useScrollDirection/useScrollDirection.test.ts
@@ -1,0 +1,142 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useScrollDirection } from './useScrollDirection';
+
+describe('useScrollDirection', () => {
+  // Controllable rAF queue: jsdom never paints, so we flush callbacks manually
+  let rafCallbacks: FrameRequestCallback[] = [];
+
+  const setScrollY = (value: number) => {
+    Object.defineProperty(window, 'scrollY', { value, configurable: true, writable: true });
+  };
+
+  const scroll = (value: number) => {
+    setScrollY(value);
+    window.dispatchEvent(new Event('scroll'));
+  };
+
+  const flushRaf = () => {
+    const pending = rafCallbacks;
+    rafCallbacks = [];
+    pending.forEach((cb) => cb(performance.now()));
+  };
+
+  beforeEach(() => {
+    rafCallbacks = [];
+    setScrollY(0);
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id: number) => {
+      rafCallbacks = rafCallbacks.filter((_, index) => index + 1 !== id);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null before any scroll', () => {
+    const { result } = renderHook(() => useScrollDirection());
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns "down" when scrolling toward the bottom', () => {
+    const { result } = renderHook(() => useScrollDirection());
+
+    act(() => {
+      scroll(200);
+      flushRaf();
+    });
+
+    expect(result.current).toBe('down');
+  });
+
+  it('returns "up" when scrolling back toward the top', () => {
+    const { result } = renderHook(() => useScrollDirection());
+
+    act(() => {
+      scroll(200);
+      flushRaf();
+    });
+    expect(result.current).toBe('down');
+
+    act(() => {
+      scroll(80);
+      flushRaf();
+    });
+    expect(result.current).toBe('up');
+  });
+
+  it('ignores deltas smaller than the threshold', () => {
+    const { result } = renderHook(() => useScrollDirection());
+
+    act(() => {
+      scroll(4); // below default threshold of 8
+      flushRaf();
+    });
+    expect(result.current).toBeNull();
+
+    act(() => {
+      scroll(7); // delta of 7 from the last accepted position (0), still ignored
+      flushRaf();
+    });
+    expect(result.current).toBeNull();
+
+    act(() => {
+      scroll(30);
+      flushRaf();
+    });
+    expect(result.current).toBe('down');
+  });
+
+  it('respects a custom threshold', () => {
+    const { result } = renderHook(() => useScrollDirection({ threshold: 100 }));
+
+    act(() => {
+      scroll(80);
+      flushRaf();
+    });
+    expect(result.current).toBeNull();
+
+    act(() => {
+      scroll(150);
+      flushRaf();
+    });
+    expect(result.current).toBe('down');
+  });
+
+  it('coalesces multiple scroll events into one rAF update', () => {
+    const { result } = renderHook(() => useScrollDirection());
+
+    act(() => {
+      scroll(100);
+      scroll(200);
+      scroll(300);
+    });
+
+    expect(rafCallbacks).toHaveLength(1);
+
+    act(() => {
+      flushRaf();
+    });
+
+    expect(result.current).toBe('down');
+  });
+
+  it('cleans up listeners and pending rAF on unmount', () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useScrollDirection());
+
+    act(() => {
+      scroll(200); // schedules a rAF
+    });
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+    expect(rafCallbacks).toHaveLength(0); // pending rAF was cancelled
+    removeEventListenerSpy.mockRestore();
+  });
+});

--- a/src/hooks/useScrollDirection/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection/useScrollDirection.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface UseScrollDirectionOptions {
+  /**
+   * Minimum scroll delta in pixels before the direction is updated.
+   * Prevents flicker from tiny scroll adjustments.
+   */
+  threshold?: number;
+}
+
+export type ScrollDirection = 'up' | 'down' | null;
+
+/**
+ * useScrollDirection
+ *
+ * Hook that tracks the vertical scroll direction of the window.
+ * Returns 'down' while the user scrolls toward the bottom, 'up' while they
+ * scroll back toward the top, and null before the first scroll.
+ *
+ * Uses requestAnimationFrame throttling so updates are aligned to frame
+ * painting and multiple scroll events within one frame collapse to one
+ * state update.
+ *
+ * @param options.threshold - Minimum delta in pixels (default: 8)
+ * @returns The current scroll direction, or null if not yet scrolled
+ *
+ * @example
+ * ```tsx
+ * const scrollDirection = useScrollDirection();
+ * const isHidden = scrollDirection === 'down';
+ * ```
+ */
+export function useScrollDirection(options: UseScrollDirectionOptions = {}): ScrollDirection {
+  const { threshold = 8 } = options;
+  const [direction, setDirection] = useState<ScrollDirection>(null);
+  const lastYRef = useRef(0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    lastYRef.current = window.scrollY;
+
+    const handleScroll = () => {
+      if (rafRef.current !== null) return;
+
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+
+        const y = window.scrollY;
+        const delta = y - lastYRef.current;
+
+        if (Math.abs(delta) < threshold) return;
+
+        lastYRef.current = y;
+        setDirection(delta > 0 ? 'down' : 'up');
+      });
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [threshold]);
+
+  return direction;
+}


### PR DESCRIPTION
fix(ui): hide mobile chrome while typing and scrolling down

Closes #2286

- MobileFooter: unmount while the soft keyboard is visible (replaces the translateY-over-the-composer hack)
- Fab: unmount while the soft keyboard is visible so the + button stops covering the text
- MobileHeader: unmount while the soft keyboard is visible and while scrolling down; returns on upward scroll (new useScrollDirection hook)

Desktop (lg+) unaffected.

Green-lit by @BitcoinErrorLog in Slack.

## Tests

- `npx vitest run --project unit <changed paths>` -> 4 files, 92 tests passed
- `npm run lint` -> clean
- `npm run typecheck` -> clean

Requested by @BitcoinErrorLog in Slack: https://synonymworkspace.slack.com/archives/C0BUJLZCWNB/p1788842628775589