### PR TITLE
fix(ui): keep onboarding header title after sign-up creates the session

### DIFF
--- a/src/components/organisms/Header/Header.test.tsx
+++ b/src/components/organisms/Header/Header.test.tsx
@@ -560,13 +560,50 @@ describe('Header', () => {
       expect(screen.getByTestId('header-title')).toHaveTextContent('Experience');
     });
 
-    it('does not render HeaderTitle when signed in and not on a post-auth onboarding step', () => {
+    it('does not render HeaderTitle when signed in outside onboarding', () => {
       mockCurrentUserPubky = 'test-pubky-123';
       mockUsePathname.mockReturnValue(ROOT_ROUTES);
 
       render(<Header />);
 
       expect(screen.queryByTestId('header-title')).not.toBeInTheDocument();
+    });
+
+    it('keeps the key-step titles once sign-up has created the session (#2493)', () => {
+      // Sign-up runs on the pubky step, so pubky and backup are reached while authenticated;
+      // the title used to vanish there and only come back on Profile.
+      mockCurrentUserPubky = 'test-pubky-123';
+      const authenticatedKeySteps = [
+        { path: ONBOARDING_ROUTES.PUBKY, expectedTitle: 'Your pubky' },
+        { path: ONBOARDING_ROUTES.BACKUP, expectedTitle: 'Backup' },
+      ];
+
+      authenticatedKeySteps.forEach(({ path, expectedTitle }) => {
+        mockUsePathname.mockReturnValue(path);
+
+        const { rerender } = render(<Header />);
+
+        expect(screen.getByTestId('header-title')).toHaveTextContent(expectedTitle);
+
+        rerender(<></>); // Clear for next iteration
+      });
+    });
+
+    it('renders HeaderTitle on every onboarding step regardless of authentication state', () => {
+      const onboardingPaths = Object.values(ONBOARDING_ROUTES);
+
+      [null, 'test-pubky-123'].forEach((pubky) => {
+        onboardingPaths.forEach((path) => {
+          mockCurrentUserPubky = pubky;
+          mockUsePathname.mockReturnValue(path);
+
+          const { rerender } = render(<Header />);
+
+          expect(screen.getByTestId('header-title')).toBeInTheDocument();
+
+          rerender(<></>); // Clear for next iteration
+        });
+      });
     });
 
     it('renders HeaderTitle with correct title for each onboarding step', () => {
@@ -848,24 +885,24 @@ describe('Header', () => {
       mockCurrentUserPubky = 'test-pubky-123';
       rerender(<Header />);
 
-      // Should hide HeaderTitle when authenticated (not on step 5)
+      // Should hide HeaderTitle when authenticated outside onboarding
       expect(screen.queryByTestId('header-title')).not.toBeInTheDocument();
     });
 
-    it('updates HeaderTitle visibility when moving to/from step 5', () => {
+    it('updates HeaderTitle visibility when moving into onboarding while authenticated', () => {
       mockCurrentUserPubky = 'test-pubky-123';
       mockUsePathname.mockReturnValue(ROOT_ROUTES);
 
       const { rerender } = render(<Header />);
 
-      // Should not show HeaderTitle when authenticated and not on step 5
+      // Should not show HeaderTitle when authenticated outside onboarding
       expect(screen.queryByTestId('header-title')).not.toBeInTheDocument();
 
-      // Move to step 5 (profile)
+      // Move to the profile step
       mockUsePathname.mockReturnValue(ONBOARDING_ROUTES.PROFILE);
       rerender(<Header />);
 
-      // Should show HeaderTitle when on step 5, even if authenticated
+      // Should show HeaderTitle on an onboarding step, even if authenticated
       expect(screen.getByTestId('header-title')).toBeInTheDocument();
       expect(screen.getByTestId('header-title')).toHaveTextContent('Profile');
     });

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -28,8 +28,9 @@ export function Header() {
   const stepConfig = pathname ? pathToStepConfig[pathname] : undefined;
   const currentStep = stepConfig?.step ?? 1;
   const currentTitle = stepConfig?.title;
-  // Onboarding steps reached after authentication (profile setup and the Experience screens).
-  // Step numbers are not unique in the 4-step model, so match on the path instead.
+  // Onboarding steps reached after authentication (profile setup and the Experience screens): the
+  // logo must not link away mid-flow. Step numbers are not unique in the 4-step model, so match on
+  // the path instead.
   const isPostAuthOnboardingStep =
     pathname === ONBOARDING_ROUTES.PROFILE ||
     pathname === ONBOARDING_ROUTES.TAGS ||
@@ -41,9 +42,11 @@ export function Header() {
   // - Authenticated on standard app routes — MobileHeader + MobileFooter
   const shouldHideHeaderOnMobile =
     isCoreExploreRoute || isDynamicPublicRoute || (isAuthenticated && !isOnboarding && !isDynamicPublicRoute);
-  // Show title only for onboarding/logout pages (when stepConfig exists) and user is not authenticated,
-  // or during the post-auth onboarding steps (profile setup, tags of interest, follow matches)
-  const shouldShowTitle = currentTitle && (!isAuthenticated || isPostAuthOnboardingStep);
+  // Show the step title on every onboarding page regardless of auth state: sign-up happens on the
+  // pubky step, so the later key steps (pubky, backup) and the post-auth steps (profile, experience)
+  // are all reached while authenticated. Outside onboarding (i.e. /logout) the title is only for
+  // signed-out users.
+  const shouldShowTitle = currentTitle && (isOnboarding || !isAuthenticated);
 
   // App-shell layout: authenticated app pages and Explore mode (unauthenticated on a
   // public route, e.g. feed/post/profile) both render the feed + sidebars, so the header


### PR DESCRIPTION
Closes #2493

## Problem

During onboarding the header title vanished on `Your pubky` and `Backup` and only came back on `Profile` (reported in [Slack](https://synonymworkspace.slack.com/archives/C09HQTLAARF/p1788522630217629), pre-existing on prod). `AuthController.signUp` runs on the pubky step, so those two screens are reached while authenticated, and the title was gated on `!isAuthenticated` plus an allow-list of post-auth steps that did not include them.

## Fix

`Header.tsx` shows the step title on every `/onboarding/*` route regardless of auth state; `/logout` keeps the signed-out guard. The post-auth allow-list remains only for the logo's `noLink`.

## Tests

- New: pubky/backup titles render while authenticated; every onboarding route renders a title signed-in and signed-out.
- Renamed the two "step 5" tests to describe the new rule.

## Notes

- Header VRT baseline intentionally not checked per request. `HeaderTitle` markup is unchanged, so the baseline should be unaffected unless a VRT fixture renders pubky/backup while authenticated.
- Stepper count (2/4 across the browser key steps) is out of scope; being discussed in the same Slack thread.
