### PR TITLE
test(e2e): seed onboarding interest instead of assuming popular tags

### DIFF
--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       // Server-side only admin credentials (not exposed to client bundle)
       homeserverAdminUrl: process.env['HOMESERVER_ADMIN_URL'] || 'http://localhost:6288/generate_signup_token',
       homeserverAdminPassword: process.env['HOMESERVER_ADMIN_PASSWORD'] || 'admin',
+      nexusUrl: process.env['PUBKY_RUNTIME_NEXUS_URL'] || 'http://localhost:8080',
     },
     expose: {
       // slow down execution more in CI to avoid flaky tests

--- a/cypress/e2e/onboarding.cy.ts
+++ b/cypress/e2e/onboarding.cy.ts
@@ -5,6 +5,28 @@ import { createQuickPost, waitForFeedToLoad } from '../support/posts';
 import { addProfileTags } from '../support/profile';
 import { BackupType, CheckForNewPosts, HasBackedUp, OnboardingExperience } from '../support/types/enums';
 
+const waitUntilStarterPackHasUsers = (tag: string) => {
+  const deadline = Date.now() + 90_000;
+  cy.env(['nexusUrl']).then(({ nexusUrl }) => {
+    const nexusOrigin = String(nexusUrl).replace(/\/$/, '');
+    const poll = () => {
+      cy.request({
+        url: `${nexusOrigin}/v0/stream/users/ids?source=starter_pack&tags=${encodeURIComponent(tag)}&skip=0&limit=10`,
+        failOnStatusCode: false,
+      }).then((response) => {
+        const ids = Array.isArray(response.body) ? response.body : [];
+        if (ids.length > 0) return;
+        if (Date.now() >= deadline) {
+          throw new Error(`Nexus starter_pack did not index ${tag}`);
+        }
+        cy.wait(2000);
+        poll();
+      });
+    };
+    poll();
+  });
+};
+
 describe('Onboarding', () => {
   before(() => {
     slowCypressDown();
@@ -84,6 +106,7 @@ describe('Onboarding', () => {
     goToProfilePageFromHeader();
     cy.get('[data-cy="profile-filter-item-tagged"]').click();
     addProfileTags([interestTag]);
+    waitUntilStarterPackHasUsers(interestTag);
     cy.signOut(HasBackedUp.Yes);
 
     cy.onboardAsNewUser('Interested User', '', undefined, undefined, OnboardingExperience.StopAtTags);

--- a/cypress/e2e/onboarding.cy.ts
+++ b/cypress/e2e/onboarding.cy.ts
@@ -1,7 +1,9 @@
 import { slowCypressDown } from 'cypress-slow-down';
-import { BackupType, HasBackedUp, OnboardingExperience } from '../support/types/enums';
 import { backupDownloadFilePath, extendedTimeout } from '../support/common';
-import { waitForFeedToLoad } from '../support/posts';
+import { goToProfilePageFromHeader } from '../support/header';
+import { createQuickPost, waitForFeedToLoad } from '../support/posts';
+import { addProfileTags } from '../support/profile';
+import { BackupType, CheckForNewPosts, HasBackedUp, OnboardingExperience } from '../support/types/enums';
 
 describe('Onboarding', () => {
   before(() => {
@@ -72,12 +74,29 @@ describe('Onboarding', () => {
   });
 
   it('suggests people for a chosen interest, follows them all, and lands on the My network feed', () => {
+    // Docker Nexus has no popular-tag chips. Seed a user who owns this tag so
+    // starter_pack can return a match after the next signup types it in.
+    const interestTag = `e2e${Date.now().toString().slice(-8)}`;
+
+    cy.onboardAsNewUser('Tagged Seed');
+    createQuickPost(`Seed post for ${interestTag}`, [interestTag]);
+    cy.findFirstPostInFeed(CheckForNewPosts.Yes);
+    goToProfilePageFromHeader();
+    cy.get('[data-cy="profile-filter-item-tagged"]').click();
+    addProfileTags([interestTag]);
+    cy.signOut(HasBackedUp.Yes);
+
     cy.onboardAsNewUser('Interested User', '', undefined, undefined, OnboardingExperience.StopAtTags);
 
-    // Pick the first popular interest chip and continue to the follow step
     cy.get('[data-testid="tags-of-interest-form"]').within(() => {
-      cy.get('[data-testid^="popular-tag-"]', extendedTimeout()).first().click();
-      cy.get('[data-testid^="popular-tag-"][aria-pressed="true"]').should('have.length', 1);
+      cy.get('[data-testid="popular-interests-empty"], [data-testid^="popular-tag-"]', extendedTimeout()).should(
+        'exist',
+      );
+      cy.get('[data-cy="add-tag-input"]').type(`${interestTag}{enter}`);
+      // Seeded tags often land in Popular interests; otherwise they show as a custom chip
+      cy.get(
+        `[data-testid="popular-tag-${interestTag}"][aria-pressed="true"], [data-testid="interest-tag-${interestTag}"]`,
+      ).should('be.visible');
       cy.get('#profile-finish-btn').click();
     });
 


### PR DESCRIPTION
## Summary
- Fresh Docker Nexus has no `popular-tag` chips, so the Follow-step spec timed out waiting for them (app-repo and stack e2e).
- Seed a user with a unique tag, type it on Tags of interest, and accept it as either a selected popular chip or a custom chip.
- Wait until Nexus `starter_pack` returns at least one user for that tag before the second signup, so Follow is not empty while indexing is still pending.
- Nexus URL for that poll comes from `PUBKY_RUNTIME_NEXUS_URL` (same as the app), default `http://localhost:8080`.

## Test plan
- [x] Cypress `onboarding.cy.ts` locally against the staging-pin Docker stack — 9/9
- [x] Interest/Follow test locally after the `starter_pack` wait
- [x] App-repo e2e on this branch: https://github.com/pubky/pubky-app/actions/runs/34347059610 ✅ 