### PR TITLE
chore(deps): override browserslist, js-yaml, and qs to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3030,28 +3030,6 @@
         "react-dom": ">= 18 || >= 19"
       }
     },
-    "node_modules/@mdxeditor/editor/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@mdxeditor/gurx": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@mdxeditor/gurx/-/gurx-1.2.4.tgz",
@@ -8200,9 +8178,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8219,11 +8197,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001803",
-        "electron-to-chromium": "^1.5.389",
-        "node-releases": "^2.0.51",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -11897,7 +11875,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
       "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15052,13 +15029,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -17318,9 +17296,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -135,5 +135,10 @@
     "typescript": "5.9.3",
     "vite-tsconfig-paths": "6.1.1",
     "vitest-browser-react": "^2.2.0"
+  },
+  "overrides": {
+    "browserslist": "4.28.9",
+    "js-yaml": "4.3.2",
+    "qs": "6.16.0"
   }
 }


### PR DESCRIPTION
## Summary

`npm audit fix` is a **no-op** on this tree: every flagged package is a transitive dependency pinned to an exact or tilde range by its parent, so npm cannot reach the patched release without `--force`. This PR does the equivalent by hand with npm `overrides`, limited to the three packages whose fix is a patch/minor bump within the same major.

| Package | Before | After | Pinned by | Advisories |
|---|---|---|---|---|
| `browserslist` | 4.28.6 | 4.28.9 | `@serwist/next` (exact `4.28.6`) | [GHSA-c83g-rgw3-j3cx](https://github.com/advisories/GHSA-c83g-rgw3-j3cx), [GHSA-73wf-gq98-2v4g](https://github.com/advisories/GHSA-73wf-gq98-2v4g) (high) |
| `js-yaml` | 4.3.1 | 4.3.2 | `@mdxeditor/editor` (exact `4.3.1`) | [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh) (high) |
| `qs` | 6.14.2 | 6.16.0 | `@cypress/request` (`~6.14.1`) | [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26), [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx), [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g) (moderate) |

`update-browserslist-db` moves 1.2.3 → 1.3.2 as a consequence (browserslist 4.28.9 requires `^1.3.2`). The `js-yaml` override also removes the nested copy under `@mdxeditor/editor`, deduping with the one `@eslint/eslintrc` already pulls in.

Every current consumer of these three packages is already on the same major, so the overrides don't force a cross-major bump on anything. Note that npm's suggested "fix" for `browserslist` was a *downgrade* of `@serwist/next` to 9.4.1, which is why an override is the right tool here.

**Audit result:** 9 vulnerabilities (6 high, 3 moderate) → 4 (2 high, 2 moderate).

## Not included (needs `--force`)

The remaining four findings (`extract-zip` ×2 high, `uuid` moderate, both via `cypress`) resolve only by bumping `cypress` 15.10.0 → 15.21.1. That is a same-major devDependency bump, but npm flags it as outside the stated range and it touches the e2e runner, so it's left for a separate PR where the e2e suite can be exercised.

The overrides can be dropped once upstreams move: `@serwist/next` off the exact `browserslist` pin, `@mdxeditor/editor` off `js-yaml@4.3.1`, and `cypress` ≥ 15.21 (whose `@cypress/request@4` already wants `qs ^6.15.2`).

## Verification

- `npm ci` succeeds against the updated lockfile (what CI runs)
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run build` (`next build --webpack`, exercises serwist + browserslist) ✅
- `npm test` — 776 files, 13,334 tests passed, 2 skipped ✅
- `npx prettier --check package.json` ✅
- Smoke-loaded `@cypress/request`, `browserslist('defaults')`, and `js-yaml.load()` under the new versions
