### PR TITLE
fix(tags): remove tag add/remove success toasts again (#1862)

### DIFF
--- a/src/hooks/usePostTags/usePostTags.test.tsx
+++ b/src/hooks/usePostTags/usePostTags.test.tsx
@@ -163,7 +163,7 @@ describe('usePostTags', () => {
       expect(response.error).toBe('You must be logged in to add tags');
     });
 
-    it('shows a success toast when a tag is added', async () => {
+    it('does not show a success toast when a tag is added', async () => {
       const { result } = renderHook(() => usePostTags('author:post123'));
 
       let response: Awaited<ReturnType<typeof result.current.handleTagAdd>>;
@@ -172,9 +172,7 @@ describe('usePostTags', () => {
       });
 
       expect(response!).toEqual({ success: true });
-      expect(vi.mocked(toast)).toHaveBeenCalledWith({
-        title: 'Tag added',
-      });
+      expect(vi.mocked(toast)).not.toHaveBeenCalled();
     });
 
     it('shows an error toast when adding a tag fails', async () => {
@@ -240,7 +238,7 @@ describe('usePostTags', () => {
       expect(result.current.tags[0].relationship).toBe(false);
     });
 
-    it('shows a success toast when a tag is removed', async () => {
+    it('does not show a success toast when a tag is removed', async () => {
       const mockViewerId = 'viewer-123';
       vi.mocked(useAuthStore).mockImplementation(mockAuthStoreSelector(mockViewerId));
       vi.mocked(useLiveQuery).mockReturnValue([
@@ -255,9 +253,7 @@ describe('usePostTags', () => {
         await result.current.handleTagToggle({ label: 'solo-tag', relationship: true });
       });
 
-      expect(vi.mocked(toast)).toHaveBeenCalledWith({
-        title: 'Tag removed',
-      });
+      expect(vi.mocked(toast)).not.toHaveBeenCalled();
     });
 
     it('shows an error toast when removing a tag fails', async () => {
@@ -379,6 +375,7 @@ describe('usePostTags', () => {
       expect(result.current.tags[0].label).toBe('alpha');
       expect(result.current.tags[1].label).toBe('beta');
       expect(result.current.tags[2].label).toBe('gamma');
+      expect(vi.mocked(toast)).not.toHaveBeenCalled();
     });
 
     it('clears the recently-added pin when the viewer removes the tag right after adding it', async () => {

--- a/src/hooks/usePostTags/usePostTags.tsx
+++ b/src/hooks/usePostTags/usePostTags.tsx
@@ -274,9 +274,6 @@ export function usePostTags(postId: string | null | undefined, options: UsePostT
         const counter = addCounterRef.current;
         setRecentlyAddedLabels((prev) => new Map(prev).set(labelLower, counter));
 
-        toast({
-          title: 'Tag added',
-        });
         return { success: true };
       } catch {
         toast({
@@ -326,9 +323,6 @@ export function usePostTags(postId: string | null | undefined, options: UsePostT
             taggedKind: TagKind.POST,
           });
 
-          toast({
-            title: 'Tag removed',
-          });
           // Removing the tag clears its "recently added" pinning so the natural
           // ordering takes over again if it ever resurfaces.
           setRecentlyAddedLabels((prev) => {
@@ -349,10 +343,6 @@ export function usePostTags(postId: string | null | undefined, options: UsePostT
             const next = new Map(prev);
             next.delete(labelLower);
             return next;
-          });
-
-          toast({
-            title: 'Tag added',
           });
         }
       } catch {

--- a/src/hooks/useTagged/useTagged.test.tsx
+++ b/src/hooks/useTagged/useTagged.test.tsx
@@ -183,9 +183,7 @@ describe('useTagged', () => {
       taggerId: 'mock-current-user',
       taggedKind: TagKind.USER,
     });
-    expect(vi.mocked(toast)).toHaveBeenCalledWith({
-      title: 'Tag added',
-    });
+    expect(vi.mocked(toast)).not.toHaveBeenCalled();
   });
 
   it('shows an error toast when adding a tag fails', async () => {
@@ -210,7 +208,7 @@ describe('useTagged', () => {
     });
   });
 
-  it('shows a success toast when removing a tag', async () => {
+  it('does not show a success toast when removing a tag', async () => {
     mockLocalTags = [
       {
         label: 'bitcoin',
@@ -236,9 +234,36 @@ describe('useTagged', () => {
       taggerId: 'mock-current-user',
       taggedKind: TagKind.USER,
     });
-    expect(vi.mocked(toast)).toHaveBeenCalledWith({
-      title: 'Tag removed',
+    expect(vi.mocked(toast)).not.toHaveBeenCalled();
+  });
+
+  it('does not show a success toast when adding a tag via an existing chip', async () => {
+    mockLocalTags = [
+      {
+        label: 'bitcoin',
+        taggers: ['other-user'],
+        taggers_count: 1,
+        relationship: false,
+      },
+    ];
+
+    const { result } = renderHook(() => useTagged(mockUserId));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
     });
+
+    await act(async () => {
+      await result.current.handleTagToggle({ label: 'bitcoin', relationship: false });
+    });
+
+    expect(mockMocks.mockTagCreate).toHaveBeenCalledWith({
+      taggedId: mockUserId,
+      label: 'bitcoin',
+      taggerId: 'mock-current-user',
+      taggedKind: TagKind.USER,
+    });
+    expect(vi.mocked(toast)).not.toHaveBeenCalled();
   });
 
   it('shows an error toast when removing a tag fails', async () => {

--- a/src/hooks/useTagged/useTagged.tsx
+++ b/src/hooks/useTagged/useTagged.tsx
@@ -174,9 +174,6 @@ export function useTagged(userId: string | null | undefined, options: UseTaggedO
           return next;
         });
 
-        toast({
-          title: 'Tag added',
-        });
         return { success: true };
       } catch {
         toast({
@@ -227,10 +224,6 @@ export function useTagged(userId: string | null | undefined, options: UseTaggedO
 
           // TagController.commitDelete updates IndexedDB first and rolls back on homeserver failure.
           await TagController.commitDelete(params);
-
-          toast({
-            title: 'Tag removed',
-          });
         } else {
           // TagController.commitCreate updates IndexedDB first and rolls back on homeserver failure.
           await TagController.commitCreate(params);
@@ -240,10 +233,6 @@ export function useTagged(userId: string | null | undefined, options: UseTaggedO
             const next = new Map(prev);
             next.delete(labelLower);
             return next;
-          });
-
-          toast({
-            title: 'Tag added',
           });
         }
       } catch {


### PR DESCRIPTION
Closes #1862

Adding or removing a tag shows a success toast again. This was already fixed once and then came back.

### History

- **#1923** (merged 2026-05-28) removed the success toasts and added front-of-list promotion for newly added post tags.
- **#1892** (merged 2026-06-15) branched off before #1923 landed. Its toast redesign brought back the success toast calls and rewrote the tests to expect them, so CI stayed green.
- The front-of-list promotion code and its tests were never touched, so only the toast half regressed.

### Changes

Removes the three success toast calls in each of the post and profile tag hooks. Error toasts are unchanged.

Tests now assert that no toast is shown on a successful add, on a successful remove, and on an add made by clicking an existing tag chip.
